### PR TITLE
DATA: Event Filter Model Changes

### DIFF
--- a/EventHighway.Core/EventHighway.Core.csproj
+++ b/EventHighway.Core/EventHighway.Core.csproj
@@ -39,6 +39,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="DynamicExpresso.Core" Version="2.*" />
 		<PackageReference Include="RESTFulSense" Version="3.2.0" />
 		<PackageReference Include="STX.EFCore.Client" Version="3.0.0" />
 	</ItemGroup>

--- a/EventHighway.Core/Migrations/20260614191340_AddFilteringToEventListenerV2.Designer.cs
+++ b/EventHighway.Core/Migrations/20260614191340_AddFilteringToEventListenerV2.Designer.cs
@@ -4,6 +4,7 @@ using EventHighway.Core.Brokers.Storages;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EventHighway.Core.Migrations
 {
     [DbContext(typeof(StorageBroker))]
-    partial class StorageBrokerModelSnapshot : ModelSnapshot
+    [Migration("20260614191340_AddFilteringToEventListenerV2")]
+    partial class AddFilteringToEventListenerV2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EventHighway.Core/Migrations/20260614191340_AddFilteringToEventListenerV2.cs
+++ b/EventHighway.Core/Migrations/20260614191340_AddFilteringToEventListenerV2.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EventHighway.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFilteringToEventListenerV2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FilterCriteria",
+                table: "EventListenerV2s",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PromotedProperties",
+                table: "EventListenerV2s",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FilterCriteria",
+                table: "EventListenerV2s");
+
+            migrationBuilder.DropColumn(
+                name: "PromotedProperties",
+                table: "EventListenerV2s");
+        }
+    }
+}

--- a/EventHighway.Core/Models/Services/Foundations/EventCall/V2/EventCallV2.cs
+++ b/EventHighway.Core/Models/Services/Foundations/EventCall/V2/EventCallV2.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using EventHighway.Core.Models.Services.Foundations.HandlerConfigurations;
+using EventHighway.Core.Models.Services.Foundations.PromotedProperties;
 
 namespace EventHighway.Core.Models.Services.Foundations.EventCall.V2
 {
@@ -14,6 +15,8 @@ namespace EventHighway.Core.Models.Services.Foundations.EventCall.V2
         public string HandlerName { get; set; }
         public List<HandlerConfiguration> HandlerConfigurations { get; set; } = new();
         public string Content { get; set; }
+        public List<PromotedProperty> PromotedProperties { get; set; } = new();
+        public string FilterCriteria { get; set; }
         public string Response { get; set; }
         public string ResponseCode { get; set; }
         public string ResponseMessage { get; set; }

--- a/EventHighway.Core/Models/Services/Foundations/EventListeners/V2/EventListenerV2.cs
+++ b/EventHighway.Core/Models/Services/Foundations/EventListeners/V2/EventListenerV2.cs
@@ -18,6 +18,8 @@ namespace EventHighway.Core.Models.Services.Foundations.EventListeners.V2
         public Guid HandlerId { get; set; }
         public string HandlerName { get; set; }
         public IEnumerable<HandlerConfiguration> HandlerConfigurations { get; set; }
+        public string PromotedProperties { get; set; }
+        public string FilterCriteria { get; set; }
         public DateTimeOffset CreatedDate { get; set; }
         public DateTimeOffset UpdatedDate { get; set; }
 

--- a/EventHighway.Core/Models/Services/Foundations/PromotedProperties/PromotedProperty.cs
+++ b/EventHighway.Core/Models/Services/Foundations/PromotedProperties/PromotedProperty.cs
@@ -1,0 +1,12 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+namespace EventHighway.Core.Models.Services.Foundations.PromotedProperties
+{
+    public class PromotedProperty
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `DynamicExpresso.Core` (v2.*) NuGet dependency to `EventHighway.Core`
- Introduce `PromotedProperty` as a runtime-only transfer object (`Name`, `Value`)
- Extend `EventListenerV2` with `PromotedProperties` (CSV of JSON key names) and `FilterCriteria` (boolean expression string)
- Extend `EventCallV2` with `List<PromotedProperty> PromotedProperties` and `string FilterCriteria`
- Add EF Core migration `AddFilteringToEventListenerV2` — two nullable `nvarchar(max)` columns on `EventListenerV2s`

Both new columns are nullable so existing listeners with no filter configured are entirely unaffected.

## Test plan

- [ ] Build passes with 0 errors
- [ ] Migration applies cleanly against a local database (`dotnet ef database update`)
- [ ] Existing listeners with no `PromotedProperties` / `FilterCriteria` behave identically to before

closes #448