### PR TITLE
PROCESSINGS: EventAddressV2ProcessingService

### DIFF
--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.Register.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.Register.cs
@@ -68,5 +68,58 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
             this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
             this.loggingBrokerMock.VerifyNoOtherCalls();
         }
+
+        [Theory]
+        [MemberData(nameof(DependencyExceptions))]
+        public async Task ShouldThrowDependencyExceptionOnRegisterIfDependencyExceptionOccursAndLogItAsync(
+            Xeption dependencyException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            var expectedEventAddressV2ProcessingDependencyException =
+                new EventAddressV2ProcessingDependencyException(
+                    message: "Event address dependency error occurred, contact support.",
+                    innerException: dependencyException.InnerException as Xeption);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.AddEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    randomCancellationToken))
+                        .ThrowsAsync(dependencyException);
+
+            // when
+            ValueTask<EventAddressV2> registerEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingDependencyException
+                actualEventAddressV2ProcessingDependencyException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingDependencyException>(
+                        registerEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingDependencyException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingDependencyException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.AddEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingDependencyException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.Register.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.Register.cs
@@ -1,0 +1,72 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+using Xeptions;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidationExceptions))]
+        public async Task ShouldThrowDependencyValidationOnRegisterIfDependencyValidationErrorOccursAndLogItAsync(
+            Xeption validationException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            var expectedEventAddressV2ProcessingDependencyValidationException =
+                new EventAddressV2ProcessingDependencyValidationException(
+                    message: "Event address validation error occurred, fix the errors and try again.",
+                    innerException: validationException.InnerException as Xeption);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.AddEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    randomCancellationToken))
+                        .ThrowsAsync(validationException);
+
+            // when
+            ValueTask<EventAddressV2> registerEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingDependencyValidationException
+                actualEventAddressV2ProcessingDependencyValidationException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingDependencyValidationException>(
+                        registerEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingDependencyValidationException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingDependencyValidationException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.AddEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingDependencyValidationException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.Register.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.Register.cs
@@ -121,5 +121,65 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
             this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
             this.loggingBrokerMock.VerifyNoOtherCalls();
         }
+
+        [Fact]
+        public async Task ShouldThrowServiceExceptionOnRegisterIfExceptionOccursAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            var serviceException = new Exception();
+            serviceException.Data.Add("ErrorCode", new List<string> { "ServiceError" });
+
+            var failedEventAddressV2ProcessingServiceException =
+                new FailedEventAddressV2ProcessingServiceException(
+                    message: "Failed event address service error occurred, contact support.",
+                    innerException: serviceException,
+                    data: serviceException.Data);
+
+            var expectedEventAddressV2ProcessingServiceException =
+                new EventAddressV2ProcessingServiceException(
+                    message: "Event address service error occurred, contact support.",
+                    innerException: failedEventAddressV2ProcessingServiceException);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.AddEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    randomCancellationToken))
+                        .ThrowsAsync(serviceException);
+
+            // when
+            ValueTask<EventAddressV2> registerEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingServiceException
+                actualEventAddressV2ProcessingServiceException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingServiceException>(
+                        registerEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingServiceException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingServiceException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.AddEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingServiceException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RemoveById.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RemoveById.cs
@@ -66,5 +66,57 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
             this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
             this.loggingBrokerMock.VerifyNoOtherCalls();
         }
+
+        [Theory]
+        [MemberData(nameof(DependencyExceptions))]
+        public async Task ShouldThrowDependencyExceptionOnRemoveByIdIfDependencyExceptionOccursAndLogItAsync(
+            Xeption dependencyException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            Guid someEventAddressV2Id = GetRandomId();
+
+            var expectedEventAddressV2ProcessingDependencyException =
+                new EventAddressV2ProcessingDependencyException(
+                    message: "Event address dependency error occurred, contact support.",
+                    innerException: dependencyException.InnerException as Xeption);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    It.IsAny<Guid>(),
+                    randomCancellationToken))
+                        .ThrowsAsync(dependencyException);
+
+            // when
+            ValueTask<EventAddressV2> removeEventAddressV2ByIdTask =
+                this.eventAddressV2ProcessingService.RemoveEventAddressV2ByIdAsync(
+                    someEventAddressV2Id,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingDependencyException
+                actualEventAddressV2ProcessingDependencyException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingDependencyException>(
+                        removeEventAddressV2ByIdTask.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingDependencyException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingDependencyException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    It.IsAny<Guid>(),
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingDependencyException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RemoveById.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RemoveById.cs
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
@@ -113,6 +114,65 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
             this.loggingBrokerMock.Verify(broker =>
                 broker.LogErrorAsync(It.Is(SameExceptionAs(
                     expectedEventAddressV2ProcessingDependencyException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldThrowServiceExceptionOnRemoveByIdIfExceptionOccursAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            Guid someEventAddressV2Id = GetRandomId();
+
+            var serviceException = new Exception();
+            serviceException.Data.Add("ErrorCode", new List<string> { "ServiceError" });
+
+            var failedEventAddressV2ProcessingServiceException =
+                new FailedEventAddressV2ProcessingServiceException(
+                    message: "Failed event address service error occurred, contact support.",
+                    innerException: serviceException,
+                    data: serviceException.Data);
+
+            var expectedEventAddressV2ProcessingServiceException =
+                new EventAddressV2ProcessingServiceException(
+                    message: "Event address service error occurred, contact support.",
+                    innerException: failedEventAddressV2ProcessingServiceException);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    It.IsAny<Guid>(),
+                    randomCancellationToken))
+                        .ThrowsAsync(serviceException);
+
+            // when
+            ValueTask<EventAddressV2> removeEventAddressV2ByIdTask =
+                this.eventAddressV2ProcessingService.RemoveEventAddressV2ByIdAsync(
+                    someEventAddressV2Id,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingServiceException
+                actualEventAddressV2ProcessingServiceException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingServiceException>(
+                        removeEventAddressV2ByIdTask.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingServiceException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingServiceException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    It.IsAny<Guid>(),
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingServiceException))),
                         Times.Once);
 
             this.eventAddressV2ServiceMock.VerifyNoOtherCalls();

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RemoveById.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RemoveById.cs
@@ -1,0 +1,70 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+using Xeptions;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidationExceptions))]
+        public async Task ShouldThrowDependencyValidationOnRemoveByIdIfDependencyValidationErrorOccursAndLogItAsync(
+            Xeption validationException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            Guid someEventAddressV2Id = GetRandomId();
+
+            var expectedEventAddressV2ProcessingDependencyValidationException =
+                new EventAddressV2ProcessingDependencyValidationException(
+                    message: "Event address validation error occurred, fix the errors and try again.",
+                    innerException: validationException.InnerException as Xeption);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    It.IsAny<Guid>(),
+                    randomCancellationToken))
+                        .ThrowsAsync(validationException);
+
+            // when
+            ValueTask<EventAddressV2> removeEventAddressV2ByIdTask =
+                this.eventAddressV2ProcessingService.RemoveEventAddressV2ByIdAsync(
+                    someEventAddressV2Id,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingDependencyValidationException
+                actualEventAddressV2ProcessingDependencyValidationException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingDependencyValidationException>(
+                        removeEventAddressV2ByIdTask.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingDependencyValidationException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingDependencyValidationException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    It.IsAny<Guid>(),
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingDependencyValidationException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -62,5 +62,54 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
             this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
             this.loggingBrokerMock.VerifyNoOtherCalls();
         }
+
+        [Theory]
+        [MemberData(nameof(DependencyExceptions))]
+        public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyExceptionOccursAndLogItAsync(
+            Xeption dependencyException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            var expectedEventAddressV2ProcessingDependencyException =
+                new EventAddressV2ProcessingDependencyException(
+                    message: "Event address dependency error occurred, contact support.",
+                    innerException: dependencyException.InnerException as Xeption);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventAddressV2sAsync())
+                    .ThrowsAsync(dependencyException);
+
+            // when
+            ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RetrieveOrRegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingDependencyException
+                actualEventAddressV2ProcessingDependencyException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingDependencyException>(
+                        retrieveOrRegisterEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingDependencyException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingDependencyException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventAddressV2sAsync(),
+                    Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingDependencyException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -2,6 +2,8 @@
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
@@ -106,6 +108,62 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
             this.loggingBrokerMock.Verify(broker =>
                 broker.LogErrorAsync(It.Is(SameExceptionAs(
                     expectedEventAddressV2ProcessingDependencyException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldThrowServiceExceptionOnRetrieveOrRegisterIfExceptionOccursAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            var serviceException = new Exception();
+            serviceException.Data.Add("ErrorCode", new List<string> { "ServiceError" });
+
+            var failedEventAddressV2ProcessingServiceException =
+                new FailedEventAddressV2ProcessingServiceException(
+                    message: "Failed event address service error occurred, contact support.",
+                    innerException: serviceException,
+                    data: serviceException.Data);
+
+            var expectedEventAddressV2ProcessingServiceException =
+                new EventAddressV2ProcessingServiceException(
+                    message: "Event address service error occurred, contact support.",
+                    innerException: failedEventAddressV2ProcessingServiceException);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventAddressV2sAsync())
+                    .ThrowsAsync(serviceException);
+
+            // when
+            ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RetrieveOrRegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingServiceException
+                actualEventAddressV2ProcessingServiceException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingServiceException>(
+                        retrieveOrRegisterEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingServiceException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingServiceException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventAddressV2sAsync(),
+                    Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingServiceException))),
                         Times.Once);
 
             this.eventAddressV2ServiceMock.VerifyNoOtherCalls();

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -1,0 +1,66 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+using Xeptions;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidationExceptions))]
+        public async Task ShouldThrowDependencyValidationOnRetrieveOrRegisterIfDependencyValidationErrorOccursAndLogItAsync(
+            Xeption validationException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            var expectedEventAddressV2ProcessingDependencyValidationException =
+                new EventAddressV2ProcessingDependencyValidationException(
+                    message: "Event address validation error occurred, fix the errors and try again.",
+                    innerException: validationException.InnerException as Xeption);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventAddressV2sAsync())
+                    .ThrowsAsync(validationException);
+
+            // when
+            ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RetrieveOrRegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingDependencyValidationException
+                actualEventAddressV2ProcessingDependencyValidationException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingDependencyValidationException>(
+                        retrieveOrRegisterEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingDependencyValidationException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingDependencyValidationException);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventAddressV2sAsync(),
+                    Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingDependencyValidationException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Logic.Register.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Logic.Register.cs
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using FluentAssertions;
+using Force.DeepCloner;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Fact]
+        public async Task ShouldRegisterEventAddressV2Async()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 randomEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            EventAddressV2 inputEventAddressV2 =
+                randomEventAddressV2;
+
+            EventAddressV2 addedEventAddressV2 =
+                inputEventAddressV2;
+
+            EventAddressV2 expectedEventAddressV2 =
+                addedEventAddressV2.DeepClone();
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.AddEventAddressV2Async(
+                    inputEventAddressV2,
+                    randomCancellationToken))
+                        .ReturnsAsync(addedEventAddressV2);
+
+            // when
+            EventAddressV2 actualEventAddressV2 =
+                await this.eventAddressV2ProcessingService
+                    .RegisterEventAddressV2Async(
+                        inputEventAddressV2,
+                        randomCancellationToken);
+
+            // then
+            actualEventAddressV2.Should().BeEquivalentTo(
+                expectedEventAddressV2);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.AddEventAddressV2Async(
+                    inputEventAddressV2,
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Logic.RemoveById.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Logic.RemoveById.cs
@@ -1,0 +1,63 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using FluentAssertions;
+using Force.DeepCloner;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Fact]
+        public async Task ShouldRemoveEventAddressV2ByIdAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            Guid randomEventAddressV2Id = GetRandomId();
+            Guid inputEventAddressV2Id = randomEventAddressV2Id;
+
+            EventAddressV2 randomEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            EventAddressV2 removedEventAddressV2 =
+                randomEventAddressV2;
+
+            EventAddressV2 expectedEventAddressV2 =
+                removedEventAddressV2.DeepClone();
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    inputEventAddressV2Id,
+                    randomCancellationToken))
+                        .ReturnsAsync(removedEventAddressV2);
+
+            // when
+            EventAddressV2 actualEventAddressV2 =
+                await this.eventAddressV2ProcessingService
+                    .RemoveEventAddressV2ByIdAsync(
+                        inputEventAddressV2Id,
+                        randomCancellationToken);
+
+            // then
+            actualEventAddressV2.Should().BeEquivalentTo(
+                expectedEventAddressV2);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    inputEventAddressV2Id,
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
@@ -2,6 +2,7 @@
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
@@ -26,17 +27,15 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
             EventAddressV2 inputEventAddressV2 =
                 randomEventAddressV2;
 
-            EventAddressV2 retrievedEventAddressV2 =
-                inputEventAddressV2;
+            IQueryable<EventAddressV2> retrievedEventAddressV2s =
+                new[] { inputEventAddressV2 }.AsQueryable();
 
             EventAddressV2 expectedEventAddressV2 =
-                retrievedEventAddressV2.DeepClone();
+                inputEventAddressV2.DeepClone();
 
             this.eventAddressV2ServiceMock.Setup(service =>
-                service.RetrieveEventAddressV2ByIdAsync(
-                    inputEventAddressV2.Id,
-                    randomCancellationToken))
-                        .ReturnsAsync(retrievedEventAddressV2);
+                service.RetrieveAllEventAddressV2sAsync())
+                    .ReturnsAsync(retrievedEventAddressV2s);
 
             // when
             EventAddressV2 actualEventAddressV2 =
@@ -50,8 +49,63 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
                 expectedEventAddressV2);
 
             this.eventAddressV2ServiceMock.Verify(service =>
-                service.RetrieveEventAddressV2ByIdAsync(
-                    inputEventAddressV2.Id,
+                service.RetrieveAllEventAddressV2sAsync(),
+                    Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldRegisterEventAddressV2IfItDoesNotExistAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 randomEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            EventAddressV2 inputEventAddressV2 =
+                randomEventAddressV2;
+
+            EventAddressV2 registeredEventAddressV2 =
+                inputEventAddressV2;
+
+            EventAddressV2 expectedEventAddressV2 =
+                registeredEventAddressV2.DeepClone();
+
+            IQueryable<EventAddressV2> emptyEventAddressV2s =
+                Enumerable.Empty<EventAddressV2>().AsQueryable();
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventAddressV2sAsync())
+                    .ReturnsAsync(emptyEventAddressV2s);
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.AddEventAddressV2Async(
+                    inputEventAddressV2,
+                    randomCancellationToken))
+                        .ReturnsAsync(registeredEventAddressV2);
+
+            // when
+            EventAddressV2 actualEventAddressV2 =
+                await this.eventAddressV2ProcessingService
+                    .RetrieveOrRegisterEventAddressV2Async(
+                        inputEventAddressV2,
+                        randomCancellationToken);
+
+            // then
+            actualEventAddressV2.Should().BeEquivalentTo(
+                expectedEventAddressV2);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventAddressV2sAsync(),
+                    Times.Once);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.AddEventAddressV2Async(
+                    inputEventAddressV2,
                     randomCancellationToken),
                         Times.Once);
 

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using FluentAssertions;
+using Force.DeepCloner;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Fact]
+        public async Task ShouldRetrieveEventAddressV2IfItAlreadyExistsAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 randomEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            EventAddressV2 inputEventAddressV2 =
+                randomEventAddressV2;
+
+            EventAddressV2 retrievedEventAddressV2 =
+                inputEventAddressV2;
+
+            EventAddressV2 expectedEventAddressV2 =
+                retrievedEventAddressV2.DeepClone();
+
+            this.eventAddressV2ServiceMock.Setup(service =>
+                service.RetrieveEventAddressV2ByIdAsync(
+                    inputEventAddressV2.Id,
+                    randomCancellationToken))
+                        .ReturnsAsync(retrievedEventAddressV2);
+
+            // when
+            EventAddressV2 actualEventAddressV2 =
+                await this.eventAddressV2ProcessingService
+                    .RetrieveOrRegisterEventAddressV2Async(
+                        inputEventAddressV2,
+                        randomCancellationToken);
+
+            // then
+            actualEventAddressV2.Should().BeEquivalentTo(
+                expectedEventAddressV2);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RetrieveEventAddressV2ByIdAsync(
+                    inputEventAddressV2.Id,
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Validations.Register.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Validations.Register.cs
@@ -1,0 +1,64 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Fact]
+        public async Task ShouldThrowValidationExceptionOnRegisterIfEventAddressV2IsNullAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 nullEventAddressV2 = null;
+
+            var nullEventAddressV2ProcessingException =
+                new NullEventAddressV2ProcessingException(
+                    message: "Event address is null.");
+
+            var expectedEventAddressV2ProcessingValidationException =
+                new EventAddressV2ProcessingValidationException(
+                    message: "Event address validation error occurred, fix the errors and try again.",
+                    innerException: nullEventAddressV2ProcessingException);
+
+            // when
+            ValueTask<EventAddressV2> registerEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RegisterEventAddressV2Async(
+                    nullEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingValidationException
+                actualEventAddressV2ProcessingValidationException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingValidationException>(
+                        registerEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingValidationException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingValidationException);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingValidationException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.AddEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Never);
+
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Validations.RemoveById.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Validations.RemoveById.cs
@@ -1,0 +1,70 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Fact]
+        public async Task ShouldThrowValidationExceptionOnRemoveByIdIfIdIsInvalidAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            Guid invalidEventAddressV2Id = Guid.Empty;
+
+            var invalidEventAddressV2ProcessingException =
+                new InvalidEventAddressV2ProcessingException(
+                    message: "Event address is invalid, fix the errors and try again.");
+
+            invalidEventAddressV2ProcessingException.AddData(
+                key: nameof(EventAddressV2.Id),
+                values: "Required");
+
+            var expectedEventAddressV2ProcessingValidationException =
+                new EventAddressV2ProcessingValidationException(
+                    message: "Event address validation error occurred, fix the errors and try again.",
+                    innerException: invalidEventAddressV2ProcessingException);
+
+            // when
+            ValueTask<EventAddressV2> removeEventAddressV2ByIdTask =
+                this.eventAddressV2ProcessingService
+                    .RemoveEventAddressV2ByIdAsync(
+                        invalidEventAddressV2Id,
+                        randomCancellationToken);
+
+            EventAddressV2ProcessingValidationException
+                actualEventAddressV2ProcessingValidationException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingValidationException>(
+                        removeEventAddressV2ByIdTask.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingValidationException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingValidationException);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingValidationException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RemoveEventAddressV2ByIdAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Never);
+
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
@@ -2,6 +2,7 @@
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
@@ -35,6 +36,59 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
             ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
                 this.eventAddressV2ProcessingService.RetrieveOrRegisterEventAddressV2Async(
                     nullEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingValidationException
+                actualEventAddressV2ProcessingValidationException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingValidationException>(
+                        retrieveOrRegisterEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingValidationException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingValidationException);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingValidationException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventAddressV2sAsync(),
+                    Times.Never);
+
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldThrowValidationExceptionOnRetrieveOrRegisterIfIdIsInvalidAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 invalidEventAddressV2 =
+                CreateRandomEventAddressV2();
+
+            invalidEventAddressV2.Id = Guid.Empty;
+
+            var invalidEventAddressV2ProcessingException =
+                new InvalidEventAddressV2ProcessingException(
+                    message: "Event address is invalid, fix the errors and try again.");
+
+            invalidEventAddressV2ProcessingException.AddData(
+                key: nameof(EventAddressV2.Id),
+                values: "Required");
+
+            var expectedEventAddressV2ProcessingValidationException =
+                new EventAddressV2ProcessingValidationException(
+                    message: "Event address validation error occurred, fix the errors and try again.",
+                    innerException: invalidEventAddressV2ProcessingException);
+
+            // when
+            ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RetrieveOrRegisterEventAddressV2Async(
+                    invalidEventAddressV2,
                     randomCancellationToken);
 
             EventAddressV2ProcessingValidationException

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventAddresses.V2
+{
+    public partial class EventAddressV2ProcessingServiceTests
+    {
+        [Fact]
+        public async Task ShouldThrowValidationExceptionOnRetrieveOrRegisterIfEventAddressV2IsNullAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 nullEventAddressV2 = null;
+
+            var nullEventAddressV2ProcessingException =
+                new NullEventAddressV2ProcessingException(
+                    message: "Event address is null.");
+
+            var expectedEventAddressV2ProcessingValidationException =
+                new EventAddressV2ProcessingValidationException(
+                    message: "Event address validation error occurred, fix the errors and try again.",
+                    innerException: nullEventAddressV2ProcessingException);
+
+            // when
+            ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
+                this.eventAddressV2ProcessingService.RetrieveOrRegisterEventAddressV2Async(
+                    nullEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ProcessingValidationException
+                actualEventAddressV2ProcessingValidationException =
+                    await Assert.ThrowsAsync<EventAddressV2ProcessingValidationException>(
+                        retrieveOrRegisterEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ProcessingValidationException.Should().BeEquivalentTo(
+                expectedEventAddressV2ProcessingValidationException);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventAddressV2ProcessingValidationException))),
+                        Times.Once);
+
+            this.eventAddressV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventAddressV2sAsync(),
+                    Times.Never);
+
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core/Models/Services/Processings/EventAddresses/V2/Exceptions/NullEventAddressV2ProcessingException.cs
+++ b/EventHighway.Core/Models/Services/Processings/EventAddresses/V2/Exceptions/NullEventAddressV2ProcessingException.cs
@@ -1,0 +1,15 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using Xeptions;
+
+namespace EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions
+{
+    public class NullEventAddressV2ProcessingException : Xeption
+    {
+        public NullEventAddressV2ProcessingException(string message)
+            : base(message)
+        { }
+    }
+}

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Exceptions.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Exceptions.cs
@@ -52,6 +52,12 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
             {
                 return await returningEventAddressV2Function();
             }
+            catch (NullEventAddressV2ProcessingException
+                nullEventAddressV2ProcessingException)
+            {
+                throw await CreateAndLogValidationExceptionAsync(
+                    nullEventAddressV2ProcessingException);
+            }
             catch (InvalidEventAddressV2ProcessingException
                 invalidEventAddressV2ProcessingException)
             {

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Validations.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Validations.cs
@@ -13,6 +13,9 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
         private static void ValidateOnRegisterEventAddressV2(EventAddressV2 eventAddressV2) =>
             ValidateEventAddressV2IsNotNull(eventAddressV2);
 
+        private static void ValidateOnRemoveEventAddressV2ById(Guid eventAddressV2Id) =>
+            ValidateEventAddressV2Id(eventAddressV2Id);
+
         private static void ValidateOnRetrieveOrRegisterEventAddressV2(EventAddressV2 eventAddressV2)
         {
             ValidateEventAddressV2IsNotNull(eventAddressV2);

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Validations.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Validations.cs
@@ -10,6 +10,18 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
 {
     internal partial class EventAddressV2ProcessingService
     {
+        private static void ValidateOnRetrieveOrRegisterEventAddressV2(EventAddressV2 eventAddressV2) =>
+            ValidateEventAddressV2IsNotNull(eventAddressV2);
+
+        private static void ValidateEventAddressV2IsNotNull(EventAddressV2 eventAddressV2)
+        {
+            if (eventAddressV2 is null)
+            {
+                throw new NullEventAddressV2ProcessingException(
+                    message: "Event address is null.");
+            }
+        }
+
         private static void ValidateEventAddressV2Id(Guid eventAddressV2Id)
         {
             Validate(

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Validations.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Validations.cs
@@ -10,8 +10,16 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
 {
     internal partial class EventAddressV2ProcessingService
     {
-        private static void ValidateOnRetrieveOrRegisterEventAddressV2(EventAddressV2 eventAddressV2) =>
+        private static void ValidateOnRetrieveOrRegisterEventAddressV2(EventAddressV2 eventAddressV2)
+        {
             ValidateEventAddressV2IsNotNull(eventAddressV2);
+
+            Validate(
+                message: "Event address is invalid, fix the errors and try again.",
+
+                (Rule: IsInvalid(eventAddressV2.Id),
+                Parameter: nameof(EventAddressV2.Id)));
+        }
 
         private static void ValidateEventAddressV2IsNotNull(EventAddressV2 eventAddressV2)
         {

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Validations.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.Validations.cs
@@ -10,6 +10,9 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
 {
     internal partial class EventAddressV2ProcessingService
     {
+        private static void ValidateOnRegisterEventAddressV2(EventAddressV2 eventAddressV2) =>
+            ValidateEventAddressV2IsNotNull(eventAddressV2);
+
         private static void ValidateOnRetrieveOrRegisterEventAddressV2(EventAddressV2 eventAddressV2)
         {
             ValidateEventAddressV2IsNotNull(eventAddressV2);

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -43,14 +43,17 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
                 cancellationToken);
         });
 
-        public async ValueTask<EventAddressV2> RegisterEventAddressV2Async(
+        public ValueTask<EventAddressV2> RegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default) =>
+        TryCatch(async () =>
         {
+            ValidateOnRegisterEventAddressV2(eventAddressV2);
+
             return await this.eventAddressV2Service.AddEventAddressV2Async(
                 eventAddressV2,
                 cancellationToken);
-        }
+        });
 
         public ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -42,5 +42,12 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
                 eventAddressV2Id,
                 cancellationToken);
         });
+
+        public async ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
+            EventAddressV2 eventAddressV2,
+            CancellationToken cancellationToken = default)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -47,7 +47,18 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default)
         {
-            throw new System.NotImplementedException();
+            IQueryable<EventAddressV2> allEventAddressV2s =
+                await this.eventAddressV2Service.RetrieveAllEventAddressV2sAsync();
+
+            EventAddressV2 maybeEventAddressV2 =
+                allEventAddressV2s.FirstOrDefault(address => address.Id == eventAddressV2.Id);
+
+            if (maybeEventAddressV2 is not null)
+                return maybeEventAddressV2;
+
+            return await this.eventAddressV2Service.AddEventAddressV2Async(
+                eventAddressV2,
+                cancellationToken);
         }
     }
 }

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -43,10 +43,13 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
                 cancellationToken);
         });
 
-        public async ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
+        public ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default) =>
+        TryCatch(async () =>
         {
+            ValidateOnRetrieveOrRegisterEventAddressV2(eventAddressV2);
+
             IQueryable<EventAddressV2> allEventAddressV2s =
                 await this.eventAddressV2Service.RetrieveAllEventAddressV2sAsync();
 
@@ -59,6 +62,6 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
             return await this.eventAddressV2Service.AddEventAddressV2Async(
                 eventAddressV2,
                 cancellationToken);
-        }
+        });
     }
 }

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -47,7 +47,9 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
             Guid eventAddressV2Id,
             CancellationToken cancellationToken = default)
         {
-            throw new System.NotImplementedException();
+            return await this.eventAddressV2Service.RemoveEventAddressV2ByIdAsync(
+                eventAddressV2Id,
+                cancellationToken);
         }
 
         public ValueTask<EventAddressV2> RegisterEventAddressV2Async(

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -43,14 +43,17 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
                 cancellationToken);
         });
 
-        public async ValueTask<EventAddressV2> RemoveEventAddressV2ByIdAsync(
+        public ValueTask<EventAddressV2> RemoveEventAddressV2ByIdAsync(
             Guid eventAddressV2Id,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default) =>
+        TryCatch(async () =>
         {
+            ValidateOnRemoveEventAddressV2ById(eventAddressV2Id);
+
             return await this.eventAddressV2Service.RemoveEventAddressV2ByIdAsync(
                 eventAddressV2Id,
                 cancellationToken);
-        }
+        });
 
         public ValueTask<EventAddressV2> RegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -47,7 +47,9 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default)
         {
-            throw new System.NotImplementedException();
+            return await this.eventAddressV2Service.AddEventAddressV2Async(
+                eventAddressV2,
+                cancellationToken);
         }
 
         public ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -43,6 +43,13 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
                 cancellationToken);
         });
 
+        public async ValueTask<EventAddressV2> RemoveEventAddressV2ByIdAsync(
+            Guid eventAddressV2Id,
+            CancellationToken cancellationToken = default)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public ValueTask<EventAddressV2> RegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default) =>

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -47,9 +47,7 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default)
         {
-            return await this.eventAddressV2Service.RetrieveEventAddressV2ByIdAsync(
-                eventAddressV2.Id,
-                cancellationToken);
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -43,6 +43,13 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
                 cancellationToken);
         });
 
+        public async ValueTask<EventAddressV2> RegisterEventAddressV2Async(
+            EventAddressV2 eventAddressV2,
+            CancellationToken cancellationToken = default)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default) =>

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/EventAddressV2ProcessingService.cs
@@ -47,7 +47,9 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default)
         {
-            throw new System.NotImplementedException();
+            return await this.eventAddressV2Service.RetrieveEventAddressV2ByIdAsync(
+                eventAddressV2.Id,
+                cancellationToken);
         }
     }
 }

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/IEventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/IEventAddressV2ProcessingService.cs
@@ -21,5 +21,9 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
         ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default);
+
+        ValueTask<EventAddressV2> RegisterEventAddressV2Async(
+            EventAddressV2 eventAddressV2,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/IEventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/IEventAddressV2ProcessingService.cs
@@ -17,5 +17,9 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
         ValueTask<EventAddressV2> RetrieveEventAddressV2ByIdAsync(
             Guid eventAddressV2Id,
             CancellationToken cancellationToken = default);
+
+        ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
+            EventAddressV2 eventAddressV2,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/EventHighway.Core/Services/Processings/EventAddresses/V2/IEventAddressV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventAddresses/V2/IEventAddressV2ProcessingService.cs
@@ -25,5 +25,9 @@ namespace EventHighway.Core.Services.Processings.EventAddresses.V2
         ValueTask<EventAddressV2> RegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default);
+
+        ValueTask<EventAddressV2> RemoveEventAddressV2ByIdAsync(
+            Guid eventAddressV2Id,
+            CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `RetrieveOrRegisterEventAddressV2Async` to `IEventAddressV2ProcessingService` and `EventAddressV2ProcessingService` — checks if the address already exists (via `RetrieveAllEventAddressV2sAsync` + LINQ filter by Id) and returns it if found, otherwise adds and returns the new record
- Adds `RegisterEventAddressV2Async` to wrap `AddEventAddressV2Async` with validation
- Adds `RemoveEventAddressV2ByIdAsync` to wrap the foundation service remove with validation
- Adds `NullEventAddressV2ProcessingException` and wires it into the TryCatch exception handler
- Full logic, validation, and exception test coverage for all three methods following TDD (FAIL → PASS commit cycle)

## Test plan
- [x] All logic tests pass: `ShouldRetrieveEventAddressV2IfItAlreadyExistsAsync`, `ShouldRegisterEventAddressV2IfItDoesNotExistAsync`, `ShouldRegisterEventAddressV2Async`, `ShouldRemoveEventAddressV2ByIdAsync`
- [x] All validation tests pass: null input, invalid Id
- [x] All exception tests pass: dependency validation, dependency, and service exceptions for each method
- [x] Full test suite green

closes #465