### PR TITLE
CLIENTS: EventAddressV2Client - RetrieveOrRegisterEventAddressV2

### DIFF
--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.Register.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.Register.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Clients.EventAddresses.V2.Exceptions;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
-using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2.Exceptions;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
 using FluentAssertions;
 using Moq;
 using Xeptions;
@@ -32,8 +32,8 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
                     innerException: validationException.InnerException as Xeption,
                     data: (validationException.InnerException as Xeption).Data);
 
-            this.eventAddressV2ServiceMock.Setup(service =>
-                service.AddEventAddressV2Async(
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
+                service.RegisterEventAddressV2Async(
                     It.IsAny<EventAddressV2>(),
                     It.IsAny<CancellationToken>()))
                         .ThrowsAsync(validationException);
@@ -52,13 +52,13 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2ClientValidationException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientValidationException);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
-                service.AddEventAddressV2Async(
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
+                service.RegisterEventAddressV2Async(
                     It.IsAny<EventAddressV2>(),
                     It.IsAny<CancellationToken>()),
                         Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -73,22 +73,22 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             var someInnerException = new Xeption(someMessage);
             someInnerException.AddData(GetRandomString(), GetRandomString());
 
-            var eventAddressV2DependencyException =
-                new EventAddressV2DependencyException(
+            var eventAddressV2ProcessingDependencyException =
+                new EventAddressV2ProcessingDependencyException(
                     someMessage,
                     someInnerException);
 
             var expectedEventAddressV2ClientDependencyException =
                 new EventAddressV2ClientDependencyException(
                     message: "Event address client dependency error occurred, contact support.",
-                    innerException: eventAddressV2DependencyException.InnerException as Xeption,
-                    data: (eventAddressV2DependencyException.InnerException as Xeption).Data);
+                    innerException: eventAddressV2ProcessingDependencyException.InnerException as Xeption,
+                    data: (eventAddressV2ProcessingDependencyException.InnerException as Xeption).Data);
 
-            this.eventAddressV2ServiceMock.Setup(service =>
-                service.AddEventAddressV2Async(
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
+                service.RegisterEventAddressV2Async(
                     It.IsAny<EventAddressV2>(),
                     It.IsAny<CancellationToken>()))
-                        .ThrowsAsync(eventAddressV2DependencyException);
+                        .ThrowsAsync(eventAddressV2ProcessingDependencyException);
 
             // when
             ValueTask<EventAddressV2> registerEventAddressV2Task =
@@ -104,13 +104,13 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2ClientDependencyException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientDependencyException);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
-                service.AddEventAddressV2Async(
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
+                service.RegisterEventAddressV2Async(
                     It.IsAny<EventAddressV2>(),
                     It.IsAny<CancellationToken>()),
                         Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -125,22 +125,22 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             var someInnerException = new Xeption(someMessage);
             someInnerException.AddData(GetRandomString(), GetRandomString());
 
-            var eventAddressV2ServiceException =
-                new EventAddressV2ServiceException(
+            var eventAddressV2ProcessingServiceException =
+                new EventAddressV2ProcessingServiceException(
                     someMessage,
                     someInnerException);
 
             var expectedEventAddressV2ClientDependencyException =
                 new EventAddressV2ClientDependencyException(
                     message: "Event address client dependency error occurred, contact support.",
-                    innerException: eventAddressV2ServiceException.InnerException as Xeption,
-                    data: (eventAddressV2ServiceException.InnerException as Xeption).Data);
+                    innerException: eventAddressV2ProcessingServiceException.InnerException as Xeption,
+                    data: (eventAddressV2ProcessingServiceException.InnerException as Xeption).Data);
 
-            this.eventAddressV2ServiceMock.Setup(service =>
-                service.AddEventAddressV2Async(
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
+                service.RegisterEventAddressV2Async(
                     It.IsAny<EventAddressV2>(),
                     It.IsAny<CancellationToken>()))
-                        .ThrowsAsync(eventAddressV2ServiceException);
+                        .ThrowsAsync(eventAddressV2ProcessingServiceException);
 
             // when
             ValueTask<EventAddressV2> registerEventAddressV2Task =
@@ -156,13 +156,13 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2ClientDependencyException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientDependencyException);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
-                service.AddEventAddressV2Async(
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
+                service.RegisterEventAddressV2Async(
                     It.IsAny<EventAddressV2>(),
                     It.IsAny<CancellationToken>()),
                         Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RemoveById.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RemoveById.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Clients.EventAddresses.V2.Exceptions;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
-using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2.Exceptions;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
 using FluentAssertions;
 using Moq;
 using Xeptions;
@@ -33,7 +33,7 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
                     innerException: validationException.InnerException as Xeption,
                     data: (validationException.InnerException as Xeption).Data);
 
-            this.eventAddressV2ServiceMock.Setup(service =>
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
                 service.RemoveEventAddressV2ByIdAsync(
                     It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()))
@@ -53,13 +53,13 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2ClientValidationException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientValidationException);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
                 service.RemoveEventAddressV2ByIdAsync(
                     It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()),
                         Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -74,22 +74,22 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             var someInnerException = new Xeption(someMessage);
             someInnerException.AddData(GetRandomString(), GetRandomString());
 
-            var eventAddressV2DependencyException =
-                new EventAddressV2DependencyException(
+            var eventAddressV2ProcessingDependencyException =
+                new EventAddressV2ProcessingDependencyException(
                     someMessage,
                     someInnerException);
 
             var expectedEventAddressV2ClientDependencyException =
                 new EventAddressV2ClientDependencyException(
                     message: "Event address client dependency error occurred, contact support.",
-                    innerException: eventAddressV2DependencyException.InnerException as Xeption,
-                    data: (eventAddressV2DependencyException.InnerException as Xeption).Data);
+                    innerException: eventAddressV2ProcessingDependencyException.InnerException as Xeption,
+                    data: (eventAddressV2ProcessingDependencyException.InnerException as Xeption).Data);
 
-            this.eventAddressV2ServiceMock.Setup(service =>
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
                 service.RemoveEventAddressV2ByIdAsync(
                     It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()))
-                        .ThrowsAsync(eventAddressV2DependencyException);
+                        .ThrowsAsync(eventAddressV2ProcessingDependencyException);
 
             // when
             ValueTask<EventAddressV2> removeEventAddressV2ByIdTask =
@@ -105,13 +105,13 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2ClientDependencyException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientDependencyException);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
                 service.RemoveEventAddressV2ByIdAsync(
                     It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()),
                         Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -126,22 +126,22 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             var someInnerException = new Xeption(someMessage);
             someInnerException.AddData(GetRandomString(), GetRandomString());
 
-            var eventAddressV2ServiceException =
-                new EventAddressV2ServiceException(
+            var eventAddressV2ProcessingServiceException =
+                new EventAddressV2ProcessingServiceException(
                     someMessage,
                     someInnerException);
 
             var expectedEventAddressV2ClientDependencyException =
                 new EventAddressV2ClientDependencyException(
                     message: "Event address client dependency error occurred, contact support.",
-                    innerException: eventAddressV2ServiceException.InnerException as Xeption,
-                    data: (eventAddressV2ServiceException.InnerException as Xeption).Data);
+                    innerException: eventAddressV2ProcessingServiceException.InnerException as Xeption,
+                    data: (eventAddressV2ProcessingServiceException.InnerException as Xeption).Data);
 
-            this.eventAddressV2ServiceMock.Setup(service =>
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
                 service.RemoveEventAddressV2ByIdAsync(
                     It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()))
-                        .ThrowsAsync(eventAddressV2ServiceException);
+                        .ThrowsAsync(eventAddressV2ProcessingServiceException);
 
             // when
             ValueTask<EventAddressV2> removeEventAddressV2ByIdTask =
@@ -157,13 +157,13 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2ClientDependencyException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientDependencyException);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
                 service.RemoveEventAddressV2ByIdAsync(
                     It.IsAny<Guid>(),
                     It.IsAny<CancellationToken>()),
                         Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RetrieveAll.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RetrieveAll.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Clients.EventAddresses.V2.Exceptions;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
-using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2.Exceptions;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
 using FluentAssertions;
 using Moq;
 using Xeptions;
@@ -27,24 +27,20 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             var someInnerException = new Xeption(someMessage);
             someInnerException.AddData(GetRandomString(), GetRandomString());
 
-            var eventAddressV2DependencyException =
-                new EventAddressV2DependencyException(
+            var eventAddressV2ProcessingDependencyException =
+                new EventAddressV2ProcessingDependencyException(
                     someMessage,
                     someInnerException);
 
             var expectedEventAddressV2ClientDependencyException =
                 new EventAddressV2ClientDependencyException(
                     message: "Event address client dependency error occurred, contact support.",
+                    innerException: eventAddressV2ProcessingDependencyException.InnerException as Xeption,
+                    data: (eventAddressV2ProcessingDependencyException.InnerException as Xeption).Data);
 
-                    innerException: eventAddressV2DependencyException
-                        .InnerException as Xeption,
-
-                    data: (eventAddressV2DependencyException
-                        .InnerException as Xeption).Data);
-
-            this.eventAddressV2ServiceMock.Setup(service =>
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
                 service.RetrieveAllEventAddressV2sAsync())
-                    .ThrowsAsync(eventAddressV2DependencyException);
+                    .ThrowsAsync(eventAddressV2ProcessingDependencyException);
 
             // when
             ValueTask<IQueryable<EventAddressV2>> retrieveAllEventAddressV2sTask =
@@ -58,11 +54,11 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2ClientDependencyException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientDependencyException);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
                 service.RetrieveAllEventAddressV2sAsync(),
                     Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -76,24 +72,20 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             var someInnerException = new Xeption(someMessage);
             someInnerException.AddData(GetRandomString(), GetRandomString());
 
-            var eventAddressV2ServiceException =
-                new EventAddressV2ServiceException(
+            var eventAddressV2ProcessingServiceException =
+                new EventAddressV2ProcessingServiceException(
                     someMessage,
                     someInnerException);
 
             var expectedEventAddressV2ClientDependencyException =
                 new EventAddressV2ClientDependencyException(
                     message: "Event address client dependency error occurred, contact support.",
+                    innerException: eventAddressV2ProcessingServiceException.InnerException as Xeption,
+                    data: (eventAddressV2ProcessingServiceException.InnerException as Xeption).Data);
 
-                    innerException: eventAddressV2ServiceException
-                        .InnerException as Xeption,
-
-                    data: (eventAddressV2ServiceException
-                        .InnerException as Xeption).Data);
-
-            this.eventAddressV2ServiceMock.Setup(service =>
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
                 service.RetrieveAllEventAddressV2sAsync())
-                    .ThrowsAsync(eventAddressV2ServiceException);
+                    .ThrowsAsync(eventAddressV2ProcessingServiceException);
 
             // when
             ValueTask<IQueryable<EventAddressV2>> retrieveAllEventAddressV2sTask =
@@ -107,11 +99,11 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2ClientDependencyException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientDependencyException);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
                 service.RetrieveAllEventAddressV2sAsync(),
                     Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RetrieveOrRegister.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Clients.EventAddresses.V2.Exceptions;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
 using FluentAssertions;
 using Moq;
 using Xeptions;
@@ -50,6 +51,58 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             // then
             actualEventAddressV2ClientValidationException.Should()
                 .BeEquivalentTo(expectedEventAddressV2ClientValidationException);
+
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyErrorOccursAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 = CreateRandomEventAddressV2();
+            string someMessage = GetRandomString();
+            var someInnerException = new Xeption(someMessage);
+            someInnerException.AddData(GetRandomString(), GetRandomString());
+
+            var eventAddressV2ProcessingDependencyException =
+                new EventAddressV2ProcessingDependencyException(
+                    someMessage,
+                    someInnerException);
+
+            var expectedEventAddressV2ClientDependencyException =
+                new EventAddressV2ClientDependencyException(
+                    message: "Event address client dependency error occurred, contact support.",
+                    innerException: eventAddressV2ProcessingDependencyException.InnerException as Xeption,
+                    data: (eventAddressV2ProcessingDependencyException.InnerException as Xeption).Data);
+
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(eventAddressV2ProcessingDependencyException);
+
+            // when
+            ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
+                this.eventAddressV2Client.RetrieveOrRegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ClientDependencyException actualEventAddressV2ClientDependencyException =
+                await Assert.ThrowsAsync<EventAddressV2ClientDependencyException>(
+                    retrieveOrRegisterEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ClientDependencyException.Should()
+                .BeEquivalentTo(expectedEventAddressV2ClientDependencyException);
 
             this.eventAddressV2ProcessingServiceMock.Verify(service =>
                 service.RetrieveOrRegisterEventAddressV2Async(

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RetrieveOrRegister.cs
@@ -112,5 +112,57 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
 
             this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
+
+        [Fact]
+        public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfServiceErrorOccursAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 = CreateRandomEventAddressV2();
+            string someMessage = GetRandomString();
+            var someInnerException = new Xeption(someMessage);
+            someInnerException.AddData(GetRandomString(), GetRandomString());
+
+            var eventAddressV2ProcessingServiceException =
+                new EventAddressV2ProcessingServiceException(
+                    someMessage,
+                    someInnerException);
+
+            var expectedEventAddressV2ClientDependencyException =
+                new EventAddressV2ClientDependencyException(
+                    message: "Event address client dependency error occurred, contact support.",
+                    innerException: eventAddressV2ProcessingServiceException.InnerException as Xeption,
+                    data: (eventAddressV2ProcessingServiceException.InnerException as Xeption).Data);
+
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(eventAddressV2ProcessingServiceException);
+
+            // when
+            ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
+                this.eventAddressV2Client.RetrieveOrRegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ClientDependencyException actualEventAddressV2ClientDependencyException =
+                await Assert.ThrowsAsync<EventAddressV2ClientDependencyException>(
+                    retrieveOrRegisterEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ClientDependencyException.Should()
+                .BeEquivalentTo(expectedEventAddressV2ClientDependencyException);
+
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Exceptions.RetrieveOrRegister.cs
@@ -1,0 +1,63 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Clients.EventAddresses.V2.Exceptions;
+using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
+using FluentAssertions;
+using Moq;
+using Xeptions;
+
+namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
+{
+    public partial class EventAddressV2ClientTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidationExceptions))]
+        public async Task ShouldThrowValidationExceptionOnRetrieveOrRegisterIfValidationErrorOccursAsync(
+            Xeption validationException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventAddressV2 someEventAddressV2 = CreateRandomEventAddressV2();
+
+            var expectedEventAddressV2ClientValidationException =
+                new EventAddressV2ClientValidationException(
+                    message: "Event address client validation error occurred, fix the errors and try again.",
+                    innerException: validationException.InnerException as Xeption,
+                    data: (validationException.InnerException as Xeption).Data);
+
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(validationException);
+
+            // when
+            ValueTask<EventAddressV2> retrieveOrRegisterEventAddressV2Task =
+                this.eventAddressV2Client.RetrieveOrRegisterEventAddressV2Async(
+                    someEventAddressV2,
+                    randomCancellationToken);
+
+            EventAddressV2ClientValidationException actualEventAddressV2ClientValidationException =
+                await Assert.ThrowsAsync<EventAddressV2ClientValidationException>(
+                    retrieveOrRegisterEventAddressV2Task.AsTask);
+
+            // then
+            actualEventAddressV2ClientValidationException.Should()
+                .BeEquivalentTo(expectedEventAddressV2ClientValidationException);
+
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventAddressV2Async(
+                    It.IsAny<EventAddressV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Logic.RemoveById.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Logic.RemoveById.cs
@@ -33,7 +33,7 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             EventAddressV2 expectedEventAddressV2 =
                 removedEventAddressV2.DeepClone();
 
-            this.eventAddressV2ServiceMock.Setup(service =>
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
                 service.RemoveEventAddressV2ByIdAsync(
                     inputEventAddressV2Id,
                     randomCancellationToken))
@@ -47,16 +47,16 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
                         randomCancellationToken);
 
             // then
-            actualEventAddressV2.Should()
-                .BeEquivalentTo(expectedEventAddressV2);
+            actualEventAddressV2.Should().BeEquivalentTo(
+                expectedEventAddressV2);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
                 service.RemoveEventAddressV2ByIdAsync(
                     inputEventAddressV2Id,
                     randomCancellationToken),
                         Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Logic.RetrieveAll.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Logic.RetrieveAll.cs
@@ -30,7 +30,7 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             IQueryable<EventAddressV2> expectedEventAddressV2s =
                 retrievedEventAddressV2s.DeepClone();
 
-            this.eventAddressV2ServiceMock.Setup(service =>
+            this.eventAddressV2ProcessingServiceMock.Setup(service =>
                 service.RetrieveAllEventAddressV2sAsync())
                     .ReturnsAsync(retrievedEventAddressV2s);
 
@@ -43,11 +43,11 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             actualEventAddressV2s.Should().BeEquivalentTo(
                 expectedEventAddressV2s);
 
-            this.eventAddressV2ServiceMock.Verify(service =>
+            this.eventAddressV2ProcessingServiceMock.Verify(service =>
                 service.RetrieveAllEventAddressV2sAsync(),
                     Times.Once);
 
-            this.eventAddressV2ServiceMock.VerifyNoOtherCalls();
+            this.eventAddressV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Logic.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.Logic.RetrieveOrRegister.cs
@@ -14,7 +14,7 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
     public partial class EventAddressV2ClientTests
     {
         [Fact]
-        public async Task ShouldRegisterEventAddressV2Async()
+        public async Task ShouldRetrieveOrRegisterEventAddressV2Async()
         {
             // given
             CancellationToken randomCancellationToken =
@@ -26,31 +26,31 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
             EventAddressV2 inputEventAddressV2 =
                 randomEventAddressV2;
 
-            EventAddressV2 registeredEventAddressV2 =
+            EventAddressV2 retrievedOrRegisteredEventAddressV2 =
                 inputEventAddressV2;
 
             EventAddressV2 expectedEventAddressV2 =
-                registeredEventAddressV2.DeepClone();
+                retrievedOrRegisteredEventAddressV2.DeepClone();
 
             this.eventAddressV2ProcessingServiceMock.Setup(service =>
-                service.RegisterEventAddressV2Async(
+                service.RetrieveOrRegisterEventAddressV2Async(
                     inputEventAddressV2,
                     randomCancellationToken))
-                        .ReturnsAsync(registeredEventAddressV2);
+                        .ReturnsAsync(retrievedOrRegisteredEventAddressV2);
 
             // when
             EventAddressV2 actualEventAddressV2 =
                 await this.eventAddressV2Client
-                    .RegisterEventAddressV2Async(
+                    .RetrieveOrRegisterEventAddressV2Async(
                         inputEventAddressV2,
                         randomCancellationToken);
 
             // then
-            actualEventAddressV2.Should()
-                .BeEquivalentTo(expectedEventAddressV2);
+            actualEventAddressV2.Should().BeEquivalentTo(
+                expectedEventAddressV2);
 
             this.eventAddressV2ProcessingServiceMock.Verify(service =>
-                service.RegisterEventAddressV2Async(
+                service.RetrieveOrRegisterEventAddressV2Async(
                     inputEventAddressV2,
                     randomCancellationToken),
                         Times.Once);

--- a/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventAddresses/V2/EventAddressV2ClientTests.cs
@@ -6,8 +6,8 @@ using System;
 using System.Linq;
 using EventHighway.Core.Clients.EventAddresses.V2;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
-using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2.Exceptions;
-using EventHighway.Core.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
+using EventHighway.Core.Services.Processings.EventAddresses.V2;
 using Moq;
 using Tynamix.ObjectFiller;
 using Xeptions;
@@ -16,31 +16,33 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventAddresses.V2
 {
     public partial class EventAddressV2ClientTests
     {
-        private readonly Mock<IEventAddressV2Service> eventAddressV2ServiceMock;
+        private readonly Mock<IEventAddressV2ProcessingService> eventAddressV2ProcessingServiceMock;
         private readonly IEventAddressV2Client eventAddressV2Client;
 
         public EventAddressV2ClientTests()
         {
-            this.eventAddressV2ServiceMock =
-                new Mock<IEventAddressV2Service>();
+            this.eventAddressV2ProcessingServiceMock =
+                new Mock<IEventAddressV2ProcessingService>();
 
             this.eventAddressV2Client =
                 new EventAddressV2Client(
-                    eventAddressV2Service: this.eventAddressV2ServiceMock.Object);
+                    eventAddressV2ProcessingService:
+                        this.eventAddressV2ProcessingServiceMock.Object);
         }
 
         public static TheoryData<Xeption> ValidationExceptions()
         {
             string someMessage = GetRandomString();
-            var someInnerException = new Xeption();
+            var someInnerException = new Xeption(someMessage);
+            someInnerException.AddData(GetRandomString(), GetRandomString());
 
             return new TheoryData<Xeption>
             {
-                new EventAddressV2ValidationException(
+                new EventAddressV2ProcessingValidationException(
                     someMessage,
                     someInnerException),
 
-                new EventAddressV2DependencyValidationException(
+                new EventAddressV2ProcessingDependencyValidationException(
                     someMessage,
                     someInnerException),
             };

--- a/EventHighway.Core/Clients/EventAddresses/V2/EventAddressV2Client.cs
+++ b/EventHighway.Core/Clients/EventAddresses/V2/EventAddressV2Client.cs
@@ -64,7 +64,39 @@ namespace EventHighway.Core.Clients.EventAddresses.V2
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            try
+            {
+                return await this.eventAddressV2ProcessingService
+                    .RetrieveOrRegisterEventAddressV2Async(eventAddressV2, cancellationToken);
+            }
+            catch (EventAddressV2ProcessingValidationException
+                eventAddressV2ProcessingValidationException)
+            {
+                throw CreateEventAddressV2ClientValidationException(
+                    eventAddressV2ProcessingValidationException.InnerException as Xeption);
+            }
+            catch (EventAddressV2ProcessingDependencyValidationException
+                eventAddressV2ProcessingDependencyValidationException)
+            {
+                throw CreateEventAddressV2ClientValidationException(
+                    eventAddressV2ProcessingDependencyValidationException.InnerException as Xeption);
+            }
+            catch (EventAddressV2ProcessingDependencyException
+                eventAddressV2ProcessingDependencyException)
+            {
+                throw CreateEventAddressV2ClientDependencyException(
+                    eventAddressV2ProcessingDependencyException.InnerException as Xeption);
+            }
+            catch (EventAddressV2ProcessingServiceException
+                eventAddressV2ProcessingServiceException)
+            {
+                throw CreateEventAddressV2ClientDependencyException(
+                    eventAddressV2ProcessingServiceException.InnerException as Xeption);
+            }
+            catch (Exception exception)
+            {
+                throw CreateEventAddressV2ClientServiceException(exception as Xeption);
+            }
         }
 
         public async ValueTask<IQueryable<EventAddressV2>> RetrieveAllEventAddressV2sAsync(

--- a/EventHighway.Core/Clients/EventAddresses/V2/EventAddressV2Client.cs
+++ b/EventHighway.Core/Clients/EventAddresses/V2/EventAddressV2Client.cs
@@ -8,76 +8,51 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Clients.EventAddresses.V2.Exceptions;
 using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2;
-using EventHighway.Core.Models.Services.Foundations.EventAddresses.V2.Exceptions;
-using EventHighway.Core.Services.Foundations.EventAddresses.V2;
+using EventHighway.Core.Models.Services.Processings.EventAddresses.V2.Exceptions;
+using EventHighway.Core.Services.Processings.EventAddresses.V2;
 using Xeptions;
 
 namespace EventHighway.Core.Clients.EventAddresses.V2
 {
-    /// <summary>
-    /// Represents the V2 event address client implementation, handling event address
-    /// registration, retrieval, and removal operations while managing service exceptions.
-    /// </summary>
     internal class EventAddressV2Client : IEventAddressV2Client
     {
-        private readonly IEventAddressV2Service eventAddressV2Service;
+        private readonly IEventAddressV2ProcessingService eventAddressV2ProcessingService;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventAddressV2Client"/> class with
-        /// the specified event address service.
-        /// </summary>
-        /// <param name="eventAddressV2Service">The service for managing event addresses.</param>
-        /// <exception cref="ArgumentNullException">Thrown when eventAddressV2Service is
-        /// null.</exception>
-        public EventAddressV2Client(IEventAddressV2Service eventAddressV2Service) =>
-            this.eventAddressV2Service = eventAddressV2Service;
+        public EventAddressV2Client(IEventAddressV2ProcessingService eventAddressV2ProcessingService) =>
+            this.eventAddressV2ProcessingService = eventAddressV2ProcessingService;
 
-        /// <summary>
-        /// Registers a new event address asynchronously by delegating to the service and
-        /// handling any exceptions that occur.
-        /// </summary>
-        /// <param name="eventAddressV2">The event address to register.</param>
-        /// <param name="cancellationToken">A cancellation token to allow cancellation of the
-        /// asynchronous operation. The default value is
-        /// <see cref="CancellationToken.None"/>.</param>
-        /// <returns>A <see cref="ValueTask{EventAddressV2}"/> representing the asynchronous
-        /// operation that returns the registered event address.</returns>
-        /// <exception cref="EventAddressV2ClientValidationException">Thrown when validation
-        /// errors occur in the service.</exception>
-        /// <exception cref="EventAddressV2ClientDependencyException">Thrown when dependency
-        /// or service errors occur.</exception>
-        /// <exception cref="EventAddressV2ClientServiceException">Thrown when an unexpected
-        /// error occurs during registration.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the cancellation token is
-        /// signaled.</exception>
         public async ValueTask<EventAddressV2> RegisterEventAddressV2Async(
             EventAddressV2 eventAddressV2,
             CancellationToken cancellationToken = default)
         {
             try
             {
-                return await this.eventAddressV2Service
-                    .AddEventAddressV2Async(eventAddressV2, cancellationToken);
+                return await this.eventAddressV2ProcessingService
+                    .RegisterEventAddressV2Async(eventAddressV2, cancellationToken);
             }
-            catch (EventAddressV2ValidationException eventAddressV2ValidationException)
+            catch (EventAddressV2ProcessingValidationException
+                eventAddressV2ProcessingValidationException)
             {
                 throw CreateEventAddressV2ClientValidationException(
-                    eventAddressV2ValidationException.InnerException as Xeption);
+                    eventAddressV2ProcessingValidationException.InnerException as Xeption);
             }
-            catch (EventAddressV2DependencyValidationException eventAddressV2DependencyValidationException)
+            catch (EventAddressV2ProcessingDependencyValidationException
+                eventAddressV2ProcessingDependencyValidationException)
             {
                 throw CreateEventAddressV2ClientValidationException(
-                    eventAddressV2DependencyValidationException.InnerException as Xeption);
+                    eventAddressV2ProcessingDependencyValidationException.InnerException as Xeption);
             }
-            catch (EventAddressV2DependencyException eventAddressV2DependencyException)
+            catch (EventAddressV2ProcessingDependencyException
+                eventAddressV2ProcessingDependencyException)
             {
                 throw CreateEventAddressV2ClientDependencyException(
-                    eventAddressV2DependencyException.InnerException as Xeption);
+                    eventAddressV2ProcessingDependencyException.InnerException as Xeption);
             }
-            catch (EventAddressV2ServiceException eventAddressV2ServiceException)
+            catch (EventAddressV2ProcessingServiceException
+                eventAddressV2ProcessingServiceException)
             {
                 throw CreateEventAddressV2ClientDependencyException(
-                    eventAddressV2ServiceException.InnerException as Xeption);
+                    eventAddressV2ProcessingServiceException.InnerException as Xeption);
             }
             catch (Exception exception)
             {
@@ -85,37 +60,31 @@ namespace EventHighway.Core.Clients.EventAddresses.V2
             }
         }
 
-        /// <summary>
-        /// Retrieves all event addresses asynchronously by delegating to the service and
-        /// handling any exceptions that occur.
-        /// </summary>
-        /// <param name="cancellationToken">A cancellation token to allow cancellation of the
-        /// asynchronous operation. The default value is
-        /// <see cref="CancellationToken.None"/>.</param>
-        /// <returns>A <see cref="ValueTask{IQueryable}"/> representing the asynchronous
-        /// operation that returns a queryable collection of all event addresses.</returns>
-        /// <exception cref="EventAddressV2ClientDependencyException">Thrown when dependency
-        /// or service errors occur.</exception>
-        /// <exception cref="EventAddressV2ClientServiceException">Thrown when an unexpected
-        /// error occurs during retrieval.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the cancellation token is
-        /// signaled.</exception>
+        public async ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
+            EventAddressV2 eventAddressV2,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public async ValueTask<IQueryable<EventAddressV2>> RetrieveAllEventAddressV2sAsync(
             CancellationToken cancellationToken = default)
         {
             try
             {
-                return await this.eventAddressV2Service.RetrieveAllEventAddressV2sAsync();
+                return await this.eventAddressV2ProcessingService.RetrieveAllEventAddressV2sAsync();
             }
-            catch (EventAddressV2DependencyException eventAddressV2DependencyException)
+            catch (EventAddressV2ProcessingDependencyException
+                eventAddressV2ProcessingDependencyException)
             {
                 throw CreateEventAddressV2ClientDependencyException(
-                    eventAddressV2DependencyException.InnerException as Xeption);
+                    eventAddressV2ProcessingDependencyException.InnerException as Xeption);
             }
-            catch (EventAddressV2ServiceException eventAddressV2ServiceException)
+            catch (EventAddressV2ProcessingServiceException
+                eventAddressV2ProcessingServiceException)
             {
                 throw CreateEventAddressV2ClientDependencyException(
-                    eventAddressV2ServiceException.InnerException as Xeption);
+                    eventAddressV2ProcessingServiceException.InnerException as Xeption);
             }
             catch (Exception exception)
             {
@@ -123,52 +92,38 @@ namespace EventHighway.Core.Clients.EventAddresses.V2
             }
         }
 
-        /// <summary>
-        /// Removes an event address by its identifier asynchronously by delegating to the
-        /// service and handling any exceptions that occur.
-        /// </summary>
-        /// <param name="eventAddressV2Id">The identifier of the event address to remove.</param>
-        /// <param name="cancellationToken">A cancellation token to allow cancellation of the
-        /// asynchronous operation. The default value is
-        /// <see cref="CancellationToken.None"/>.</param>
-        /// <returns>A <see cref="ValueTask{EventAddressV2}"/> representing the asynchronous
-        /// operation that returns the removed event address.</returns>
-        /// <exception cref="EventAddressV2ClientValidationException">Thrown when validation
-        /// errors occur in the service.</exception>
-        /// <exception cref="EventAddressV2ClientDependencyException">Thrown when dependency
-        /// or service errors occur.</exception>
-        /// <exception cref="EventAddressV2ClientServiceException">Thrown when an unexpected
-        /// error occurs during removal.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the cancellation token is
-        /// signaled.</exception>
         public async ValueTask<EventAddressV2> RemoveEventAddressV2ByIdAsync(
             Guid eventAddressV2Id,
             CancellationToken cancellationToken = default)
         {
             try
             {
-                return await this.eventAddressV2Service
+                return await this.eventAddressV2ProcessingService
                     .RemoveEventAddressV2ByIdAsync(eventAddressV2Id, cancellationToken);
             }
-            catch (EventAddressV2ValidationException eventAddressV2ValidationException)
+            catch (EventAddressV2ProcessingValidationException
+                eventAddressV2ProcessingValidationException)
             {
                 throw CreateEventAddressV2ClientValidationException(
-                    eventAddressV2ValidationException.InnerException as Xeption);
+                    eventAddressV2ProcessingValidationException.InnerException as Xeption);
             }
-            catch (EventAddressV2DependencyValidationException eventAddressV2DependencyValidationException)
+            catch (EventAddressV2ProcessingDependencyValidationException
+                eventAddressV2ProcessingDependencyValidationException)
             {
                 throw CreateEventAddressV2ClientValidationException(
-                    eventAddressV2DependencyValidationException.InnerException as Xeption);
+                    eventAddressV2ProcessingDependencyValidationException.InnerException as Xeption);
             }
-            catch (EventAddressV2DependencyException eventAddressV2DependencyException)
+            catch (EventAddressV2ProcessingDependencyException
+                eventAddressV2ProcessingDependencyException)
             {
                 throw CreateEventAddressV2ClientDependencyException(
-                    eventAddressV2DependencyException.InnerException as Xeption);
+                    eventAddressV2ProcessingDependencyException.InnerException as Xeption);
             }
-            catch (EventAddressV2ServiceException eventAddressV2ServiceException)
+            catch (EventAddressV2ProcessingServiceException
+                eventAddressV2ProcessingServiceException)
             {
                 throw CreateEventAddressV2ClientDependencyException(
-                    eventAddressV2ServiceException.InnerException as Xeption);
+                    eventAddressV2ProcessingServiceException.InnerException as Xeption);
             }
             catch (Exception exception)
             {

--- a/EventHighway.Core/Clients/EventAddresses/V2/IEventAddressV2Client.cs
+++ b/EventHighway.Core/Clients/EventAddresses/V2/IEventAddressV2Client.cs
@@ -33,6 +33,13 @@ namespace EventHighway.Core.Clients.EventAddresses.V2
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Retrieves an existing event address or registers a new one asynchronously.
+        /// </summary>
+        ValueTask<EventAddressV2> RetrieveOrRegisterEventAddressV2Async(
+            EventAddressV2 eventAddressV2,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Retrieves all event addresses asynchronously.
         /// </summary>
         /// <param name="cancellationToken">A cancellation token to allow cancellation of the


### PR DESCRIPTION
## Summary
- Swaps `IEventAddressV2Service` dependency on `EventAddressV2Client` for `IEventAddressV2ProcessingService`
- Adds `RetrieveOrRegisterEventAddressV2Async` to `IEventAddressV2Client` and `EventAddressV2Client`, delegating to the processing service
- Updates all existing client tests to use the processing service mock and processing exceptions
- Full logic and exception test coverage for `RetrieveOrRegisterEventAddressV2Async`

## Test plan
- [x] `ShouldRetrieveOrRegisterEventAddressV2Async` passes
- [x] Validation exception test passes (covers both processing validation and dependency-validation exceptions)
- [x] Dependency exception test passes
- [x] Service exception test passes
- [x] All 17 client tests green

closes #466 