### PR TITLE
PROCESSINGS: EventListenerV2 - RetrieveOrRegisterEventListenerV2

### DIFF
--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -2,6 +2,8 @@
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
@@ -21,11 +23,8 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
                 Xeption validationException)
         {
             // given
-            CancellationToken randomCancellationToken =
-                TestContext.Current.CancellationToken;
-
-            EventListenerV2 someEventListenerV2 =
-                CreateRandomEventListenerV2();
+            CancellationToken randomCancellationToken = TestContext.Current.CancellationToken;
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
 
             var expectedEventListenerV2ProcessingDependencyValidationException =
                 new EventListenerV2ProcessingDependencyValidationException(
@@ -63,18 +62,15 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
             this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
             this.loggingBrokerMock.VerifyNoOtherCalls();
         }
+
         [Theory]
         [MemberData(nameof(DependencyExceptions))]
-        public async Task
-            ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyErrorOccursAsync(
-                Xeption dependencyException)
+        public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyErrorOccursAsync(
+            Xeption dependencyException)
         {
             // given
-            CancellationToken randomCancellationToken =
-                TestContext.Current.CancellationToken;
-
-            EventListenerV2 someEventListenerV2 =
-                CreateRandomEventListenerV2();
+            CancellationToken randomCancellationToken = TestContext.Current.CancellationToken;
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
 
             var expectedEventListenerV2ProcessingDependencyException =
                 new EventListenerV2ProcessingDependencyException(
@@ -107,6 +103,59 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
             this.loggingBrokerMock.Verify(broker =>
                 broker.LogErrorAsync(It.Is(SameExceptionAs(
                     expectedEventListenerV2ProcessingDependencyException))),
+                        Times.Once);
+
+            this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task ShouldThrowServiceExceptionOnRetrieveOrRegisterIfServiceErrorOccursAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken = TestContext.Current.CancellationToken;
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
+
+            var serviceException = new Exception();
+            serviceException.Data.Add("ErrorCode", new List<string> { "ServiceError" });
+
+            var failedEventListenerV2ProcessingServiceException =
+                new FailedEventListenerV2ProcessingServiceException(
+                    message: "Failed event listener service error occurred, contact support.",
+                    innerException: serviceException,
+                    data: serviceException.Data);
+
+            var expectedEventListenerV2ProcessingServiceException =
+                new EventListenerV2ProcessingServiceException(
+                    message: "Event listener service error occurred, contact support.",
+                    innerException: failedEventListenerV2ProcessingServiceException);
+
+            this.eventListenerV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventListenerV2sAsync())
+                    .ThrowsAsync(serviceException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2ProcessingService.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2ProcessingServiceException
+                actualEventListenerV2ProcessingServiceException =
+                    await Assert.ThrowsAsync<EventListenerV2ProcessingServiceException>(
+                        retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2ProcessingServiceException.Should().BeEquivalentTo(
+                expectedEventListenerV2ProcessingServiceException);
+
+            this.eventListenerV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventListenerV2sAsync(),
+                    Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventListenerV2ProcessingServiceException))),
                         Times.Once);
 
             this.eventListenerV2ServiceMock.VerifyNoOtherCalls();

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -63,5 +63,54 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
             this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
             this.loggingBrokerMock.VerifyNoOtherCalls();
         }
+        [Theory]
+        [MemberData(nameof(DependencyExceptions))]
+        public async Task
+            ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyErrorOccursAsync(
+                Xeption dependencyException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 someEventListenerV2 =
+                CreateRandomEventListenerV2();
+
+            var expectedEventListenerV2ProcessingDependencyException =
+                new EventListenerV2ProcessingDependencyException(
+                    message: "Event listener dependency error occurred, contact support.",
+                    innerException: dependencyException.InnerException as Xeption);
+
+            this.eventListenerV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventListenerV2sAsync())
+                    .ThrowsAsync(dependencyException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2ProcessingService.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2ProcessingDependencyException
+                actualEventListenerV2ProcessingDependencyException =
+                    await Assert.ThrowsAsync<EventListenerV2ProcessingDependencyException>(
+                        retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2ProcessingDependencyException.Should().BeEquivalentTo(
+                expectedEventListenerV2ProcessingDependencyException);
+
+            this.eventListenerV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventListenerV2sAsync(),
+                    Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventListenerV2ProcessingDependencyException))),
+                        Times.Once);
+
+            this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -1,0 +1,67 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
+using EventHighway.Core.Models.Services.Processings.EventListeners.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+using Xeptions;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
+{
+    public partial class EventListenerV2ProcessingServiceTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidationExceptions))]
+        public async Task
+            ShouldThrowDependencyValidationOnRetrieveOrRegisterIfDependencyValidationErrorOccursAndLogItAsync(
+                Xeption validationException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 someEventListenerV2 =
+                CreateRandomEventListenerV2();
+
+            var expectedEventListenerV2ProcessingDependencyValidationException =
+                new EventListenerV2ProcessingDependencyValidationException(
+                    message: "Event listener validation error occurred, fix the errors and try again.",
+                    innerException: validationException.InnerException as Xeption);
+
+            this.eventListenerV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventListenerV2sAsync())
+                    .ThrowsAsync(validationException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2ProcessingService.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2ProcessingDependencyValidationException
+                actualEventListenerV2ProcessingDependencyValidationException =
+                    await Assert.ThrowsAsync<EventListenerV2ProcessingDependencyValidationException>(
+                        retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2ProcessingDependencyValidationException.Should().BeEquivalentTo(
+                expectedEventListenerV2ProcessingDependencyValidationException);
+
+            this.eventListenerV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventListenerV2sAsync(),
+                    Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventListenerV2ProcessingDependencyValidationException))),
+                        Times.Once);
+
+            this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
@@ -1,15 +1,14 @@
-// ----------------------------------------------------------------------------------
+﻿// ----------------------------------------------------------------------------------
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
 using FluentAssertions;
 using Force.DeepCloner;
 using Moq;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
 {
@@ -56,6 +55,7 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
             this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
             this.loggingBrokerMock.VerifyNoOtherCalls();
         }
+
         [Fact]
         public async Task ShouldRegisterEventListenerV2IfItDoesNotExistAsync()
         {

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
@@ -2,6 +2,7 @@
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,6 +52,62 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
             this.eventListenerV2ServiceMock.Verify(service =>
                 service.RetrieveAllEventListenerV2sAsync(),
                     Times.Once);
+
+            this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+        [Fact]
+        public async Task ShouldRegisterEventListenerV2IfItDoesNotExistAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 randomEventListenerV2 =
+                CreateRandomEventListenerV2();
+
+            EventListenerV2 inputEventListenerV2 =
+                randomEventListenerV2;
+
+            EventListenerV2 registeredEventListenerV2 =
+                inputEventListenerV2;
+
+            EventListenerV2 expectedEventListenerV2 =
+                registeredEventListenerV2.DeepClone();
+
+            IQueryable<EventListenerV2> emptyEventListenerV2s =
+                Enumerable.Empty<EventListenerV2>().AsQueryable();
+
+            this.eventListenerV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventListenerV2sAsync())
+                    .ReturnsAsync(emptyEventListenerV2s);
+
+            this.eventListenerV2ServiceMock.Setup(service =>
+                service.AddEventListenerV2Async(
+                    inputEventListenerV2,
+                    randomCancellationToken))
+                        .ReturnsAsync(registeredEventListenerV2);
+
+            // when
+            EventListenerV2 actualEventListenerV2 =
+                await this.eventListenerV2ProcessingService
+                    .RetrieveOrRegisterEventListenerV2Async(
+                        inputEventListenerV2,
+                        randomCancellationToken);
+
+            // then
+            actualEventListenerV2.Should().BeEquivalentTo(
+                expectedEventListenerV2);
+
+            this.eventListenerV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventListenerV2sAsync(),
+                    Times.Once);
+
+            this.eventListenerV2ServiceMock.Verify(service =>
+                service.AddEventListenerV2Async(
+                    inputEventListenerV2,
+                    randomCancellationToken),
+                        Times.Once);
 
             this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
             this.loggingBrokerMock.VerifyNoOtherCalls();

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Logic.RetrieveOrRegister.cs
@@ -1,0 +1,59 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
+using FluentAssertions;
+using Force.DeepCloner;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
+{
+    public partial class EventListenerV2ProcessingServiceTests
+    {
+        [Fact]
+        public async Task ShouldRetrieveEventListenerV2IfItAlreadyExistsAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 randomEventListenerV2 =
+                CreateRandomEventListenerV2();
+
+            EventListenerV2 inputEventListenerV2 =
+                randomEventListenerV2;
+
+            IQueryable<EventListenerV2> retrievedEventListenerV2s =
+                new[] { inputEventListenerV2 }.AsQueryable();
+
+            EventListenerV2 expectedEventListenerV2 =
+                inputEventListenerV2.DeepClone();
+
+            this.eventListenerV2ServiceMock.Setup(service =>
+                service.RetrieveAllEventListenerV2sAsync())
+                    .ReturnsAsync(retrievedEventListenerV2s);
+
+            // when
+            EventListenerV2 actualEventListenerV2 =
+                await this.eventListenerV2ProcessingService
+                    .RetrieveOrRegisterEventListenerV2Async(
+                        inputEventListenerV2,
+                        randomCancellationToken);
+
+            // then
+            actualEventListenerV2.Should().BeEquivalentTo(
+                expectedEventListenerV2);
+
+            this.eventListenerV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventListenerV2sAsync(),
+                    Times.Once);
+
+            this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
@@ -1,0 +1,63 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
+using EventHighway.Core.Models.Services.Processings.EventListeners.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
+{
+    public partial class EventListenerV2ProcessingServiceTests
+    {
+        [Fact]
+        public async Task ShouldThrowValidationExceptionOnRetrieveOrRegisterIfEventListenerV2IsNullAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 nullEventListenerV2 = null;
+
+            var nullEventListenerV2ProcessingException =
+                new NullEventListenerV2ProcessingException(
+                    message: "Event listener is null.");
+
+            var expectedEventListenerV2ProcessingValidationException =
+                new EventListenerV2ProcessingValidationException(
+                    message: "Event listener validation error occurred, fix the errors and try again.",
+                    innerException: nullEventListenerV2ProcessingException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2ProcessingService.RetrieveOrRegisterEventListenerV2Async(
+                    nullEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2ProcessingValidationException
+                actualEventListenerV2ProcessingValidationException =
+                    await Assert.ThrowsAsync<EventListenerV2ProcessingValidationException>(
+                        retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2ProcessingValidationException.Should().BeEquivalentTo(
+                expectedEventListenerV2ProcessingValidationException);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventListenerV2ProcessingValidationException))),
+                        Times.Once);
+
+            this.eventListenerV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventListenerV2sAsync(),
+                    Times.Never);
+
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
@@ -1,4 +1,4 @@
-// ----------------------------------------------------------------------------------
+﻿// ----------------------------------------------------------------------------------
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
@@ -59,6 +59,7 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
             this.loggingBrokerMock.VerifyNoOtherCalls();
             this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
         }
+
         [Fact]
         public async Task ShouldThrowValidationExceptionOnRetrieveOrRegisterIfIdIsInvalidAndLogItAsync()
         {

--- a/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Processings/EventListeners/V2/EventListenerV2ProcessingServiceTests.Validations.RetrieveOrRegister.cs
@@ -59,5 +59,57 @@ namespace EventHighway.Core.Tests.Unit.Services.Processings.EventListeners.V2
             this.loggingBrokerMock.VerifyNoOtherCalls();
             this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
         }
+        [Fact]
+        public async Task ShouldThrowValidationExceptionOnRetrieveOrRegisterIfIdIsInvalidAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 invalidEventListenerV2 =
+                CreateRandomEventListenerV2();
+
+            invalidEventListenerV2.Id = Guid.Empty;
+
+            var invalidEventListenerV2ProcessingException =
+                new InvalidEventListenerV2ProcessingException(
+                    message: "Event listener is invalid, fix the errors and try again.");
+
+            invalidEventListenerV2ProcessingException.AddData(
+                key: nameof(EventListenerV2.Id),
+                values: "Required");
+
+            var expectedEventListenerV2ProcessingValidationException =
+                new EventListenerV2ProcessingValidationException(
+                    message: "Event listener validation error occurred, fix the errors and try again.",
+                    innerException: invalidEventListenerV2ProcessingException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2ProcessingService.RetrieveOrRegisterEventListenerV2Async(
+                    invalidEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2ProcessingValidationException
+                actualEventListenerV2ProcessingValidationException =
+                    await Assert.ThrowsAsync<EventListenerV2ProcessingValidationException>(
+                        retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2ProcessingValidationException.Should().BeEquivalentTo(
+                expectedEventListenerV2ProcessingValidationException);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventListenerV2ProcessingValidationException))),
+                        Times.Once);
+
+            this.eventListenerV2ServiceMock.Verify(service =>
+                service.RetrieveAllEventListenerV2sAsync(),
+                    Times.Never);
+
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.eventListenerV2ServiceMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.Validations.cs
+++ b/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.Validations.cs
@@ -10,6 +10,17 @@ namespace EventHighway.Core.Services.Processings.EventListeners.V2
 {
     internal partial class EventListenerV2ProcessingService
     {
+        private static void ValidateOnRetrieveOrRegisterEventListenerV2(EventListenerV2 eventListenerV2)
+        {
+            ValidateEventListenerV2IsNotNull(eventListenerV2);
+
+            Validate(
+                message: "Event listener is invalid, fix the errors and try again.",
+
+                (Rule: IsInvalid(eventListenerV2.Id),
+                Parameter: nameof(EventListenerV2.Id)));
+        }
+
         private static void ValidateEventAddressId(Guid eventAddressId)
         {
             Validate(

--- a/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.cs
@@ -67,5 +67,10 @@ namespace EventHighway.Core.Services.Processings.EventListeners.V2
                 eventListenerV2Id,
                 cancellationToken);
         });
+
+        public ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+            EventListenerV2 eventListenerV2,
+            CancellationToken cancellationToken = default) =>
+            throw new System.NotImplementedException();
     }
 }

--- a/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.cs
@@ -68,10 +68,13 @@ namespace EventHighway.Core.Services.Processings.EventListeners.V2
                 cancellationToken);
         });
 
-        public async ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+        public ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
             EventListenerV2 eventListenerV2,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default) =>
+        TryCatch(async () =>
         {
+            ValidateEventListenerV2IsNotNull(eventListenerV2);
+
             IQueryable<EventListenerV2> allEventListenerV2s =
                 await this.eventListenerV2Service.RetrieveAllEventListenerV2sAsync();
 
@@ -84,6 +87,6 @@ namespace EventHighway.Core.Services.Processings.EventListeners.V2
             return await this.eventListenerV2Service.AddEventListenerV2Async(
                 eventListenerV2,
                 cancellationToken);
-        }
+        });
     }
 }

--- a/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.cs
@@ -73,7 +73,7 @@ namespace EventHighway.Core.Services.Processings.EventListeners.V2
             CancellationToken cancellationToken = default) =>
         TryCatch(async () =>
         {
-            ValidateEventListenerV2IsNotNull(eventListenerV2);
+            ValidateOnRetrieveOrRegisterEventListenerV2(eventListenerV2);
 
             IQueryable<EventListenerV2> allEventListenerV2s =
                 await this.eventListenerV2Service.RetrieveAllEventListenerV2sAsync();

--- a/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventListeners/V2/EventListenerV2ProcessingService.cs
@@ -68,9 +68,22 @@ namespace EventHighway.Core.Services.Processings.EventListeners.V2
                 cancellationToken);
         });
 
-        public ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+        public async ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
             EventListenerV2 eventListenerV2,
-            CancellationToken cancellationToken = default) =>
-            throw new System.NotImplementedException();
+            CancellationToken cancellationToken = default)
+        {
+            IQueryable<EventListenerV2> allEventListenerV2s =
+                await this.eventListenerV2Service.RetrieveAllEventListenerV2sAsync();
+
+            EventListenerV2 maybeEventListenerV2 =
+                allEventListenerV2s.FirstOrDefault(listener => listener.Id == eventListenerV2.Id);
+
+            if (maybeEventListenerV2 is not null)
+                return maybeEventListenerV2;
+
+            return await this.eventListenerV2Service.AddEventListenerV2Async(
+                eventListenerV2,
+                cancellationToken);
+        }
     }
 }

--- a/EventHighway.Core/Services/Processings/EventListeners/V2/IEventListenerV2ProcessingService.cs
+++ b/EventHighway.Core/Services/Processings/EventListeners/V2/IEventListenerV2ProcessingService.cs
@@ -25,5 +25,9 @@ namespace EventHighway.Core.Services.Processings.EventListeners.V2
         ValueTask<EventListenerV2> RemoveEventListenerV2ByIdAsync(
             Guid eventListenerV2Id,
             CancellationToken cancellationToken = default);
+
+        ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+            EventListenerV2 eventListenerV2,
+            CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `RetrieveOrRegisterEventListenerV2Async` to `IEventListenerV2ProcessingService`
- Implements retrieve-then-register logic: returns existing listener by Id, or adds if not found
- Full test coverage: logic, validation (null + invalid Id), and exception (dependency validation, dependency, service) tests

## Test plan
- [ ] All 1228 unit tests pass
- [ ] Logic: ShouldRetrieveEventListenerV2IfItAlreadyExistsAsync
- [ ] Logic: ShouldRegisterEventListenerV2IfItDoesNotExistAsync
- [ ] Validation: ShouldThrowValidationExceptionOnRetrieveOrRegisterIfEventListenerV2IsNullAndLogItAsync
- [ ] Validation: ShouldThrowValidationExceptionOnRetrieveOrRegisterIfIdIsInvalidAndLogItAsync
- [ ] Exception: ShouldThrowDependencyValidationOnRetrieveOrRegisterIfDependencyValidationErrorOccursAndLogItAsync
- [ ] Exception: ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyErrorOccursAsync
- [ ] Exception: ShouldThrowServiceExceptionOnRetrieveOrRegisterIfServiceErrorOccursAndLogItAsync

closes #467