### PR TITLE
ORCHESTRATIONS: EventListenerV2 - RetrieveOrRegisterEventListenerV2

### DIFF
--- a/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -123,5 +123,64 @@ namespace EventHighway.Core.Tests.Unit.Services.Orchestrations.EventListeners.V2
             this.loggingBrokerMock.VerifyNoOtherCalls();
             this.listenerEventV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
+        [Fact]
+        public async Task ShouldThrowServiceExceptionOnRetrieveOrRegisterIfServiceExceptionOccursAndLogItAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
+            var serviceException = new Exception();
+            serviceException.Data.Add("ErrorCode", new List<string> { "ServiceError" });
+
+            var failedEventListenerV2OrchestrationServiceException =
+                new FailedEventListenerV2OrchestrationServiceException(
+                    message: "Failed event listener service error occurred, contact support.",
+                    innerException: serviceException,
+                    data: serviceException.Data);
+
+            var expectedEventListenerV2OrchestrationServiceException =
+                new EventListenerV2OrchestrationServiceException(
+                    message: "Event listener service error occurred, contact support.",
+                    innerException: failedEventListenerV2OrchestrationServiceException);
+
+            this.eventListenerV2ProcessingServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(serviceException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2OrchestrationService.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2OrchestrationServiceException
+                actualEventListenerV2OrchestrationServiceException =
+                    await Assert.ThrowsAsync<EventListenerV2OrchestrationServiceException>(
+                        retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2OrchestrationServiceException.Should()
+                .BeEquivalentTo(expectedEventListenerV2OrchestrationServiceException);
+
+            this.eventListenerV2ProcessingServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventListenerV2OrchestrationServiceException))),
+                        Times.Once);
+
+            this.eventListenerV2ProcessingServiceMock.VerifyNoOtherCalls();
+            this.eventHandlerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.listenerEventV2ProcessingServiceMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -1,4 +1,4 @@
-// ----------------------------------------------------------------------------------
+﻿// ----------------------------------------------------------------------------------
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
@@ -70,6 +70,7 @@ namespace EventHighway.Core.Tests.Unit.Services.Orchestrations.EventListeners.V2
             this.loggingBrokerMock.VerifyNoOtherCalls();
             this.listenerEventV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
+
         [Theory]
         [MemberData(nameof(EventListenerV2DependencyExceptions))]
         public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyExceptionOccursAndLogItAsync(
@@ -123,6 +124,7 @@ namespace EventHighway.Core.Tests.Unit.Services.Orchestrations.EventListeners.V2
             this.loggingBrokerMock.VerifyNoOtherCalls();
             this.listenerEventV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
+
         [Fact]
         public async Task ShouldThrowServiceExceptionOnRetrieveOrRegisterIfServiceExceptionOccursAndLogItAsync()
         {

--- a/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -70,5 +70,58 @@ namespace EventHighway.Core.Tests.Unit.Services.Orchestrations.EventListeners.V2
             this.loggingBrokerMock.VerifyNoOtherCalls();
             this.listenerEventV2ProcessingServiceMock.VerifyNoOtherCalls();
         }
+        [Theory]
+        [MemberData(nameof(EventListenerV2DependencyExceptions))]
+        public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyExceptionOccursAndLogItAsync(
+            Xeption dependencyException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
+
+            var expectedEventListenerV2OrchestrationDependencyException =
+                new EventListenerV2OrchestrationDependencyException(
+                    message: "Event listener dependency error occurred, contact support.",
+                    innerException: dependencyException.InnerException as Xeption);
+
+            this.eventListenerV2ProcessingServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(dependencyException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2OrchestrationService.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2OrchestrationDependencyException
+                actualEventListenerV2OrchestrationDependencyException =
+                    await Assert.ThrowsAsync<EventListenerV2OrchestrationDependencyException>(
+                        retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2OrchestrationDependencyException.Should()
+                .BeEquivalentTo(expectedEventListenerV2OrchestrationDependencyException);
+
+            this.eventListenerV2ProcessingServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventListenerV2OrchestrationDependencyException))),
+                        Times.Once);
+
+            this.eventListenerV2ProcessingServiceMock.VerifyNoOtherCalls();
+            this.eventHandlerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.listenerEventV2ProcessingServiceMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Exceptions.RetrieveOrRegister.cs
@@ -1,0 +1,74 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
+using EventHighway.Core.Models.Services.Orchestrations.EventListeners.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+using Xeptions;
+
+namespace EventHighway.Core.Tests.Unit.Services.Orchestrations.EventListeners.V2
+{
+    public partial class EventListenerV2OrchestrationServiceTests
+    {
+        [Theory]
+        [MemberData(nameof(EventListenerV2ValidationExceptions))]
+        public async Task
+            ShouldThrowDependencyValidationExceptionOnRetrieveOrRegisterIfDependencyValidationErrorOccursAndLogItAsync(
+                Xeption validationException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
+
+            var expectedEventListenerV2OrchestrationDependencyValidationException =
+                new EventListenerV2OrchestrationDependencyValidationException(
+                    message: "Event listener validation error occurred, fix the errors and try again.",
+                    innerException: validationException.InnerException as Xeption);
+
+            this.eventListenerV2ProcessingServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(validationException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2OrchestrationService.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2OrchestrationDependencyValidationException
+                actualEventListenerV2OrchestrationDependencyValidationException =
+                    await Assert.ThrowsAsync<EventListenerV2OrchestrationDependencyValidationException>(
+                        retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2OrchestrationDependencyValidationException.Should()
+                .BeEquivalentTo(expectedEventListenerV2OrchestrationDependencyValidationException);
+
+            this.eventListenerV2ProcessingServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.loggingBrokerMock.Verify(broker =>
+                broker.LogErrorAsync(It.Is(SameExceptionAs(
+                    expectedEventListenerV2OrchestrationDependencyValidationException))),
+                        Times.Once);
+
+            this.eventListenerV2ProcessingServiceMock.VerifyNoOtherCalls();
+            this.eventHandlerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.listenerEventV2ProcessingServiceMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Logic.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationServiceTests.Logic.RetrieveOrRegister.cs
@@ -1,0 +1,64 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
+using FluentAssertions;
+using Force.DeepCloner;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Services.Orchestrations.EventListeners.V2
+{
+    public partial class EventListenerV2OrchestrationServiceTests
+    {
+        [Fact]
+        public async Task ShouldRetrieveOrRegisterEventListenerV2Async()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 randomEventListenerV2 =
+                CreateRandomEventListenerV2();
+
+            EventListenerV2 inputEventListenerV2 =
+                randomEventListenerV2;
+
+            EventListenerV2 retrievedOrRegisteredEventListenerV2 =
+                inputEventListenerV2;
+
+            EventListenerV2 expectedEventListenerV2 =
+                retrievedOrRegisteredEventListenerV2.DeepClone();
+
+            this.eventListenerV2ProcessingServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    inputEventListenerV2,
+                    randomCancellationToken))
+                        .ReturnsAsync(retrievedOrRegisteredEventListenerV2);
+
+            // when
+            EventListenerV2 actualEventListenerV2 =
+                await this.eventListenerV2OrchestrationService
+                    .RetrieveOrRegisterEventListenerV2Async(
+                        inputEventListenerV2,
+                        randomCancellationToken);
+
+            // then
+            actualEventListenerV2.Should().BeEquivalentTo(
+                expectedEventListenerV2);
+
+            this.eventListenerV2ProcessingServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    inputEventListenerV2,
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.eventListenerV2ProcessingServiceMock.VerifyNoOtherCalls();
+            this.listenerEventV2ProcessingServiceMock.VerifyNoOtherCalls();
+            this.eventHandlerV2ServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationService.cs
+++ b/EventHighway.Core/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationService.cs
@@ -86,7 +86,10 @@ namespace EventHighway.Core.Services.Orchestrations.EventListeners.V2
         public ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
             EventListenerV2 eventListenerV2,
             CancellationToken cancellationToken = default) =>
-            throw new System.NotImplementedException();
+        TryCatch(async () =>
+            await this.eventListenerV2ProcessingService.RetrieveOrRegisterEventListenerV2Async(
+                eventListenerV2,
+                cancellationToken));
 
         public ValueTask<ListenerEventV2> AddListenerEventV2Async(
             ListenerEventV2 listenerEventV2,

--- a/EventHighway.Core/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationService.cs
+++ b/EventHighway.Core/Services/Orchestrations/EventListeners/V2/EventListenerV2OrchestrationService.cs
@@ -83,6 +83,11 @@ namespace EventHighway.Core.Services.Orchestrations.EventListeners.V2
                 cancellationToken);
         });
 
+        public ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+            EventListenerV2 eventListenerV2,
+            CancellationToken cancellationToken = default) =>
+            throw new System.NotImplementedException();
+
         public ValueTask<ListenerEventV2> AddListenerEventV2Async(
             ListenerEventV2 listenerEventV2,
             CancellationToken cancellationToken = default) =>

--- a/EventHighway.Core/Services/Orchestrations/EventListeners/V2/IEventListenerV2OrchestrationService.cs
+++ b/EventHighway.Core/Services/Orchestrations/EventListeners/V2/IEventListenerV2OrchestrationService.cs
@@ -33,6 +33,10 @@ namespace EventHighway.Core.Services.Orchestrations.EventListeners.V2
             Guid eventListenerV2Id,
             CancellationToken cancellationToken = default);
 
+        ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+            EventListenerV2 eventListenerV2,
+            CancellationToken cancellationToken = default);
+
         ValueTask<ListenerEventV2> AddListenerEventV2Async(
             ListenerEventV2 listenerEventV2,
             CancellationToken cancellationToken = default);


### PR DESCRIPTION
## Summary
- Adds `RetrieveOrRegisterEventListenerV2Async` to `IEventListenerV2OrchestrationService`
- Implements as a passthrough to `IEventListenerV2ProcessingService.RetrieveOrRegisterEventListenerV2Async`
- Full test coverage: logic and exception (dependency validation, dependency, service) tests

## Test plan
- [ ] All 1234 unit tests pass
- [ ] Logic: ShouldRetrieveOrRegisterEventListenerV2Async
- [ ] Exception: ShouldThrowDependencyValidationExceptionOnRetrieveOrRegisterIfDependencyValidationErrorOccursAndLogItAsync
- [ ] Exception: ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyExceptionOccursAndLogItAsync
- [ ] Exception: ShouldThrowServiceExceptionOnRetrieveOrRegisterIfServiceExceptionOccursAndLogItAsync

closes #473 