### PR TITLE
CLIENTS: EventListenerV2 - RetrieveOrRegisterEventListenerV2

### DIFF
--- a/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Exceptions.RetrieveOrRegister.cs
@@ -111,5 +111,56 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventListeners.V2
 
             this.eventListenerV2OrchestrationServiceMock.VerifyNoOtherCalls();
         }
+        [Fact]
+        public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfServiceErrorOccursAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
+            string someMessage = GetRandomString();
+            var someInnerException = new Xeption(someMessage);
+            someInnerException.AddData(GetRandomString(), GetRandomString());
+
+            var eventListenerV2OrchestrationServiceException =
+                new EventListenerV2OrchestrationServiceException(
+                    someMessage,
+                    someInnerException);
+
+            var expectedEventListenerV2ClientDependencyException =
+                new EventListenerV2ClientDependencyException(
+                    message: "Event listener client dependency error occurred, contact support.",
+                    innerException: eventListenerV2OrchestrationServiceException.InnerException as Xeption,
+                    data: (eventListenerV2OrchestrationServiceException.InnerException as Xeption).Data);
+
+            this.eventListenerV2OrchestrationServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(eventListenerV2OrchestrationServiceException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2Client.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2ClientDependencyException actualEventListenerV2ClientDependencyException =
+                await Assert.ThrowsAsync<EventListenerV2ClientDependencyException>(
+                    retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2ClientDependencyException.Should()
+                .BeEquivalentTo(expectedEventListenerV2ClientDependencyException);
+
+            this.eventListenerV2OrchestrationServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.eventListenerV2OrchestrationServiceMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Exceptions.RetrieveOrRegister.cs
@@ -1,4 +1,4 @@
-// ----------------------------------------------------------------------------------
+﻿// ----------------------------------------------------------------------------------
 // Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
 // ----------------------------------------------------------------------------------
 
@@ -60,6 +60,7 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventListeners.V2
 
             this.eventListenerV2OrchestrationServiceMock.VerifyNoOtherCalls();
         }
+
         [Fact]
         public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyErrorOccursAsync()
         {
@@ -111,6 +112,7 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventListeners.V2
 
             this.eventListenerV2OrchestrationServiceMock.VerifyNoOtherCalls();
         }
+
         [Fact]
         public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfServiceErrorOccursAsync()
         {

--- a/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Exceptions.RetrieveOrRegister.cs
@@ -60,5 +60,56 @@ namespace EventHighway.Core.Tests.Unit.Clients.EventListeners.V2
 
             this.eventListenerV2OrchestrationServiceMock.VerifyNoOtherCalls();
         }
+        [Fact]
+        public async Task ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyErrorOccursAsync()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
+            string someMessage = GetRandomString();
+            var someInnerException = new Xeption(someMessage);
+            someInnerException.AddData(GetRandomString(), GetRandomString());
+
+            var eventListenerV2OrchestrationDependencyException =
+                new EventListenerV2OrchestrationDependencyException(
+                    someMessage,
+                    someInnerException);
+
+            var expectedEventListenerV2ClientDependencyException =
+                new EventListenerV2ClientDependencyException(
+                    message: "Event listener client dependency error occurred, contact support.",
+                    innerException: eventListenerV2OrchestrationDependencyException.InnerException as Xeption,
+                    data: (eventListenerV2OrchestrationDependencyException.InnerException as Xeption).Data);
+
+            this.eventListenerV2OrchestrationServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(eventListenerV2OrchestrationDependencyException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2Client.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2ClientDependencyException actualEventListenerV2ClientDependencyException =
+                await Assert.ThrowsAsync<EventListenerV2ClientDependencyException>(
+                    retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2ClientDependencyException.Should()
+                .BeEquivalentTo(expectedEventListenerV2ClientDependencyException);
+
+            this.eventListenerV2OrchestrationServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.eventListenerV2OrchestrationServiceMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Exceptions.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Exceptions.RetrieveOrRegister.cs
@@ -1,0 +1,64 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Clients.EventListeners.V2.Exceptions;
+using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
+using EventHighway.Core.Models.Services.Orchestrations.EventListeners.V2.Exceptions;
+using FluentAssertions;
+using Moq;
+using Xeptions;
+
+namespace EventHighway.Core.Tests.Unit.Clients.EventListeners.V2
+{
+    public partial class EventListenerV2ClientTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidationExceptions))]
+        public async Task ShouldThrowValidationExceptionOnRetrieveOrRegisterIfValidationErrorOccursAsync(
+            Xeption validationException)
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 someEventListenerV2 = CreateRandomEventListenerV2();
+
+            var expectedEventListenerV2ClientValidationException =
+                new EventListenerV2ClientValidationException(
+                    message: "Event listener client validation error occurred, fix the errors and try again.",
+                    innerException: validationException.InnerException as Xeption,
+                    data: (validationException.InnerException as Xeption).Data);
+
+            this.eventListenerV2OrchestrationServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(validationException);
+
+            // when
+            ValueTask<EventListenerV2> retrieveOrRegisterEventListenerV2Task =
+                this.eventListenerV2Client.RetrieveOrRegisterEventListenerV2Async(
+                    someEventListenerV2,
+                    randomCancellationToken);
+
+            EventListenerV2ClientValidationException actualEventListenerV2ClientValidationException =
+                await Assert.ThrowsAsync<EventListenerV2ClientValidationException>(
+                    retrieveOrRegisterEventListenerV2Task.AsTask);
+
+            // then
+            actualEventListenerV2ClientValidationException.Should()
+                .BeEquivalentTo(expectedEventListenerV2ClientValidationException);
+
+            this.eventListenerV2OrchestrationServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    It.IsAny<EventListenerV2>(),
+                    It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+            this.eventListenerV2OrchestrationServiceMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Logic.RetrieveOrRegister.cs
+++ b/EventHighway.Core.Tests.Unit/Clients/EventListeners/V2/EventListenerV2ClientTests.Logic.RetrieveOrRegister.cs
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EventHighway.Core.Models.Services.Foundations.EventListeners.V2;
+using FluentAssertions;
+using Force.DeepCloner;
+using Moq;
+
+namespace EventHighway.Core.Tests.Unit.Clients.EventListeners.V2
+{
+    public partial class EventListenerV2ClientTests
+    {
+        [Fact]
+        public async Task ShouldRetrieveOrRegisterEventListenerV2Async()
+        {
+            // given
+            CancellationToken randomCancellationToken =
+                TestContext.Current.CancellationToken;
+
+            EventListenerV2 randomEventListenerV2 =
+                CreateRandomEventListenerV2();
+
+            EventListenerV2 inputEventListenerV2 =
+                randomEventListenerV2;
+
+            EventListenerV2 retrievedOrRegisteredEventListenerV2 =
+                inputEventListenerV2;
+
+            EventListenerV2 expectedEventListenerV2 =
+                retrievedOrRegisteredEventListenerV2.DeepClone();
+
+            this.eventListenerV2OrchestrationServiceMock.Setup(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    inputEventListenerV2,
+                    randomCancellationToken))
+                        .ReturnsAsync(retrievedOrRegisteredEventListenerV2);
+
+            // when
+            EventListenerV2 actualEventListenerV2 =
+                await this.eventListenerV2Client
+                    .RetrieveOrRegisterEventListenerV2Async(
+                        inputEventListenerV2,
+                        randomCancellationToken);
+
+            // then
+            actualEventListenerV2.Should()
+                .BeEquivalentTo(expectedEventListenerV2);
+
+            this.eventListenerV2OrchestrationServiceMock.Verify(service =>
+                service.RetrieveOrRegisterEventListenerV2Async(
+                    inputEventListenerV2,
+                    randomCancellationToken),
+                        Times.Once);
+
+            this.eventListenerV2OrchestrationServiceMock
+                .VerifyNoOtherCalls();
+        }
+    }
+}

--- a/EventHighway.Core/Clients/EventListeners/V2/EventListenerV2Client.cs
+++ b/EventHighway.Core/Clients/EventListeners/V2/EventListenerV2Client.cs
@@ -207,10 +207,44 @@ namespace EventHighway.Core.Clients.EventListeners.V2
             }
         }
 
-        public ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+        public async ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
             EventListenerV2 eventListenerV2,
-            CancellationToken cancellationToken = default) =>
-            throw new System.NotImplementedException();
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await this.eventListenerV2OrchestrationService
+                    .RetrieveOrRegisterEventListenerV2Async(eventListenerV2, cancellationToken);
+            }
+            catch (EventListenerV2OrchestrationValidationException
+                eventListenerV2OrchestrationValidationException)
+            {
+                throw CreateEventListenerV2ClientValidationException(
+                    eventListenerV2OrchestrationValidationException.InnerException as Xeption);
+            }
+            catch (EventListenerV2OrchestrationDependencyValidationException
+                eventListenerV2OrchestrationDependencyValidationException)
+            {
+                throw CreateEventListenerV2ClientValidationException(
+                    eventListenerV2OrchestrationDependencyValidationException.InnerException as Xeption);
+            }
+            catch (EventListenerV2OrchestrationDependencyException
+                eventListenerV2OrchestrationDependencyException)
+            {
+                throw CreateEventListenerV2ClientDependencyException(
+                    eventListenerV2OrchestrationDependencyException.InnerException as Xeption);
+            }
+            catch (EventListenerV2OrchestrationServiceException
+                eventListenerV2OrchestrationServiceException)
+            {
+                throw CreateEventListenerV2ClientDependencyException(
+                    eventListenerV2OrchestrationServiceException.InnerException as Xeption);
+            }
+            catch (Exception exception)
+            {
+                throw CreateEventListenerV2ClientServiceException(exception as Xeption);
+            }
+        }
 
         private static EventListenerV2ClientValidationException
             CreateEventListenerV2ClientValidationException(Xeption innerException)

--- a/EventHighway.Core/Clients/EventListeners/V2/EventListenerV2Client.cs
+++ b/EventHighway.Core/Clients/EventListeners/V2/EventListenerV2Client.cs
@@ -207,6 +207,11 @@ namespace EventHighway.Core.Clients.EventListeners.V2
             }
         }
 
+        public ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+            EventListenerV2 eventListenerV2,
+            CancellationToken cancellationToken = default) =>
+            throw new System.NotImplementedException();
+
         private static EventListenerV2ClientValidationException
             CreateEventListenerV2ClientValidationException(Xeption innerException)
         {

--- a/EventHighway.Core/Clients/EventListeners/V2/IEventListenerV2Client.cs
+++ b/EventHighway.Core/Clients/EventListeners/V2/IEventListenerV2Client.cs
@@ -67,5 +67,9 @@ namespace EventHighway.Core.Clients.EventListeners.V2
         ValueTask<EventListenerV2> RemoveEventListenerV2ByIdAsync(
             Guid eventListenerV2Id,
             CancellationToken cancellationToken = default);
+
+        ValueTask<EventListenerV2> RetrieveOrRegisterEventListenerV2Async(
+            EventListenerV2 eventListenerV2,
+            CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `RetrieveOrRegisterEventListenerV2Async` to `IEventListenerV2Client`
- Implements as a passthrough to `IEventListenerV2OrchestrationService.RetrieveOrRegisterEventListenerV2Async` with client exception translation
- Full test coverage: logic and exception (validation, dependency, service-as-dependency) tests

## Test plan
- [ ] All 1239 unit tests pass
- [ ] Logic: ShouldRetrieveOrRegisterEventListenerV2Async
- [ ] Exception: ShouldThrowValidationExceptionOnRetrieveOrRegisterIfValidationErrorOccursAsync
- [ ] Exception: ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfDependencyErrorOccursAsync
- [ ] Exception: ShouldThrowDependencyExceptionOnRetrieveOrRegisterIfServiceErrorOccursAsync

closes #474 